### PR TITLE
Fix issue #118 with support for h, d, negatives, and underscores in string Consts

### DIFF
--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -520,7 +520,7 @@ def _convert_verilog_str(val, bitwidth=None):
             sval = sval[1:]
         sval = sval.replace('_', '')
         num = int(sval, base)
-    except ValueError:
+    except (IndexError, ValueError):
         raise PyrtlError('error, string for Const not in verilog style format')
     if neg and num:
         if (num >> bitwidth-1):

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -497,22 +497,27 @@ def _validate_const_int(val, bitwidth=None):
 
 
 def _convert_verilog_str(val, bitwidth=None):
+    bases = {'b': 2, 'o': 8, 'd': 10, 'h': 16}
     if bitwidth is not None:
         raise PyrtlError('error, bitwidth parameter of const should be'
                          ' unspecified when the const is created from a string'
                          ' (instead use verilog style specification)')
     if val.startswith('-'):
         raise PyrtlError('verilog-style consts must be positive')
-    split_string = val.split("'")
+    split_string = val.lower().split("'")
     if len(split_string) != 2:
         raise PyrtlError('error, string for Const not in verilog style format')
     try:
         bitwidth = int(split_string[0])
-        if split_string[1][0].isdigit():
-            num = int(split_string[1])
+        if split_string[1][0] in bases:
+            base = bases[split_string[1][0]]
+            sval = split_string[1][1:]
+        elif split_string[1][0].isdigit():
+            base = 10
+            sval = split_string[1]
         else:
-            # this handles strings such as 32'b5 by converting them as int(0b5)
-            num = int('0' + split_string[1], 0)
+            raise PyrtlError('error, string for Const not in verilog style format')
+        num = int(sval, base)
     except ValueError:
         raise PyrtlError('error, string for Const not in verilog style format')
     return num, bitwidth

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -497,7 +497,7 @@ def _validate_const_int(val, bitwidth=None):
 
 
 def _convert_verilog_str(val, bitwidth=None):
-    bases = {'b': 2, 'o': 8, 'd': 10, 'h': 16}
+    bases = {'b': 2, 'o': 8, 'd': 10, 'h': 16, 'x': 16}
     if bitwidth is not None:
         raise PyrtlError('error, bitwidth parameter of const should be'
                          ' unspecified when the const is created from a string'
@@ -527,6 +527,7 @@ def _convert_verilog_str(val, bitwidth=None):
             raise PyrtlError('insufficient bits for negative number')
         num = (1 << bitwidth) - num
     return num, bitwidth
+
 
 class Register(WireVector):
     """ A WireVector with a register state element embedded.

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -204,9 +204,13 @@ class TestConst(unittest.TestCase):
         self.check_const("1'1", 1, 1)
         self.check_const("5'3", 3, 5)
         self.check_const("5'b11", 3, 5)
+        self.check_const("-5'b11", 29, 5)
         self.check_const("16'xff", 0xff, 16)
         self.check_const("17'xff", 0xff, 17)
+        self.check_const("16'hff", 0xff, 16)
+        self.check_const("17'hff", 0xff, 17)
         self.check_const("5'b011", 3, 5)
+        self.check_const("5'b0_11", 3, 5)
 
     def test_bad_string(self):
         self.assert_bad_const("1")

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -211,6 +211,8 @@ class TestConst(unittest.TestCase):
         self.check_const("17'hff", 0xff, 17)
         self.check_const("5'b011", 3, 5)
         self.check_const("5'b0_11", 3, 5)
+        self.check_const("5'02_1", 21, 5)
+        self.check_const("16'HFF", 0xff, 16)
 
     def test_bad_string(self):
         self.assert_bad_const("1")
@@ -218,16 +220,18 @@ class TestConst(unittest.TestCase):
         self.assert_bad_const("1bx")
         self.assert_bad_const("1ba")
         self.assert_bad_const("1'bx")
+        self.assert_bad_const("1'z0")
         self.assert_bad_const("1'ba")
         self.assert_bad_const("1'b10")
+        self.assert_bad_const("4'h12")
+        self.assert_bad_const("-'h1")
+        self.assert_bad_const("-2'b10")
         self.assert_bad_const("1'-b10")
         self.assert_bad_const("-1'b10")
         self.assert_bad_const("5'b111111'")
         self.assert_bad_const("'")
         self.assert_bad_const("'1")
-
-    @unittest.skip
-    def test_badstring_broken(self):
+        self.assert_bad_const("2'b01", bitwidth=3)
         self.assert_bad_const("1'")
 
     def test_bool(self):


### PR DESCRIPTION
This makes the parsing of Verilog-style consts match more closely with actual Verilog behavior, and removes the dependence on the specifics of Python syntax as parsed by `int(x, 0)`.