### PR TITLE
print_vcd() sanitized and WVIndexer added

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -9,6 +9,7 @@ modes -- access methods for "modes" such as debug
 from __future__ import print_function, unicode_literals
 import collections
 import re
+import keyword
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 
@@ -572,49 +573,6 @@ debug_mode = False
 _setting_keep_wirevector_call_stack = False
 _setting_slower_but_more_descriptive_tmps = False
 
-# some functions for generating unique names.  Keeping them synced
-# between subclasses of Block was problematic, so instead they should just
-# be kept as global
-_tempvar_count = 1
-_memid_count = 0
-
-
-def next_constvar_name(val):
-    global _tempvar_count
-    wire_name = ''.join(['const', str(_tempvar_count), '_', str(val)])
-    _tempvar_count += 1
-    return wire_name
-
-
-def next_memid():
-    global _memid_count
-    _memid_count += 1
-    return _memid_count
-
-
-def next_tempvar_name(name=None):
-    global _tempvar_count
-    wire_name = None
-
-    if name is not None:
-        if name.lower() in ['clk', 'clock']:
-            raise PyrtlError('Clock signals should never be explicit')
-        wire_name = name
-    else:
-        callpoint = _get_useful_callpoint_name()
-        if callpoint:
-            filename, lineno = callpoint
-            # strip out non alphanumeric characters
-            safename = re.sub('[\W]+', '', filename)
-            wire_name = 'tmp%d_%s_line%d' % (_tempvar_count, safename, lineno)
-            _tempvar_count += 1
-
-    if not wire_name:
-        wire_name = 'tmp%d' % _tempvar_count
-        _tempvar_count += 1
-
-    return wire_name
-
 
 def _get_useful_callpoint_name():
     """ Attempts to find the lowest user-level call into the pyrtl module
@@ -709,3 +667,71 @@ def set_debug_mode(debug=True):
     debug_mode = debug
     _setting_keep_wirevector_call_stack = debug
     _setting_slower_but_more_descriptive_tmps = debug
+
+
+py_regex = '^[^\d\W]\w*\Z'
+
+
+class NameIndexer(object):
+    """ Provides internal names that are based on a prefix and an index"""
+    def __init__(self, internal_prefix='_sani_temp'):
+        self.internal_prefix = internal_prefix
+        self.internal_index = 0
+
+    def make_valid_string(self):
+        """ Inputting a value for the first time """
+        internal_name = self.internal_prefix + str(self.internal_index)
+        self.internal_index += 1
+        return internal_name
+
+
+class NameSanitizer(NameIndexer):
+    """
+    Sanitizes the names so that names can be used in places that don't allow
+    for arbitrary names while not mangling valid names
+
+    Put the values you want to validate into make_valid_string the first time
+    you want to sanitize a particular string (or before the first time), and
+    retrieve from the NameSanitizer through indexing directly thereafter
+    eg: sani["__&sfhs"] for retrieval after the first time
+
+    """
+    def __init__(self, identifier_regex_str, internal_prefix='_sani_temp', map_valid_vals=True):
+        self.identifier = re.compile(identifier_regex_str)
+        self.val_map = {}
+        self.map_valid = map_valid_vals
+        super(NameSanitizer, self).__init__(internal_prefix)
+
+    def __getitem__(self, item):
+        """ Get a value from the sanitizer"""
+        if not self.map_valid and self.is_valid_str(item):
+            return item
+        return self.val_map[item]
+
+    def is_valid_str(self, string):
+        return re.match(self.identifier, string) and self._extra_checks(string)
+
+    def _extra_checks(self, string):
+        return True
+
+    def make_valid_string(self, string=''):
+        """ Inputting a value for the first time """
+        if not self.is_valid_str(string):
+            if string in self.val_map:
+                raise IndexError("Value {} has already been given to the sanitizer".format(string))
+            internal_name = super(NameSanitizer, self).make_valid_string()
+            self.val_map[string] = internal_name
+            return internal_name
+        else:
+            if self.map_valid:
+                self.val_map[string] = string
+            return string
+
+
+class PythonSanitizer(NameSanitizer):
+    """ Name Sanitizer specifically built for Python identifers"""
+    def __init__(self, internal_prefix='_sani_temp', map_valid_vals=True):
+        super(PythonSanitizer, self).__init__(py_regex, internal_prefix, map_valid_vals)
+
+    def _extra_checks(self, str):
+        return not keyword.iskeyword(str)

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -11,7 +11,6 @@ get_block: get the block of the arguments, throw error if they are different
 
 from __future__ import print_function, unicode_literals
 
-import keyword
 import re
 import six
 
@@ -324,73 +323,6 @@ def _currently_in_ipython():
         return True
     except NameError:
         return False
-
-py_regex = '^[^\d\W]\w*\Z'
-
-
-class NameIndexer(object):
-    """ Provides internal names that are based on a prefix and an index"""
-    def __init__(self, internal_prefix='_sani_temp'):
-        self.internal_prefix = internal_prefix
-        self.internal_index = 0
-
-    def make_valid_string(self):
-        """ Inputting a value for the first time """
-        internal_name = self.internal_prefix + str(self.internal_index)
-        self.internal_index += 1
-        return internal_name
-
-
-class NameSanitizer(NameIndexer):
-    """
-    Sanitizes the names so that names can be used in places that don't allow
-    for arbitrary names while not mangling valid names
-
-    Put the values you want to validate into make_valid_string the first time
-    you want to sanitize a particular string (or before the first time), and
-    retrieve from the NameSanitizer through indexing directly thereafter
-    eg: sani["__&sfhs"] for retrieval after the first time
-
-    """
-    def __init__(self, identifier_regex_str, internal_prefix='_sani_temp', map_valid_vals=True):
-        self.identifier = re.compile(identifier_regex_str)
-        self.val_map = {}
-        self.map_valid = map_valid_vals
-        super(NameSanitizer, self).__init__(internal_prefix)
-
-    def __getitem__(self, item):
-        """ Get a value from the sanitizer"""
-        if not self.map_valid and self.is_valid_str(item):
-            return item
-        return self.val_map[item]
-
-    def is_valid_str(self, string):
-        return re.match(self.identifier, string) and self._extra_checks(string)
-
-    def _extra_checks(self, string):
-        return True
-
-    def make_valid_string(self, string=''):
-        """ Inputting a value for the first time """
-        if not self.is_valid_str(string):
-            if string in self.val_map:
-                raise IndexError("Value {} has already been given to the sanitizer".format(string))
-            internal_name = super(NameSanitizer, self).make_valid_string()
-            self.val_map[string] = internal_name
-            return internal_name
-        else:
-            if self.map_valid:
-                self.val_map[string] = string
-            return string
-
-
-class PythonSanitizer(NameSanitizer):
-    """ Name Sanitizer specifically built for Python identifers"""
-    def __init__(self, internal_prefix='_sani_temp', map_valid_vals=True):
-        super(PythonSanitizer, self).__init__(py_regex, internal_prefix, map_valid_vals)
-
-    def _extra_checks(self, str):
-        return not keyword.iskeyword(str)
 
 
 class _NetCount(object):

--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -11,10 +11,9 @@ import re
 import collections
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
-from .core import working_block
+from .core import working_block, NameSanitizer
 from .wire import WireVector, Input, Output, Const, Register
 from .corecircuits import concat
-from .helperfuncs import NameSanitizer
 
 
 # -----------------------------------------------------------------

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -14,8 +14,8 @@ from __future__ import print_function, unicode_literals
 import collections
 
 from .pyrtlexceptions import PyrtlError
-from .core import working_block, next_tempvar_name, next_memid, LogicNet
-from .wire import WireVector, Const
+from .core import working_block, LogicNet
+from .wire import WireVector, Const, wvIndexer
 from .helperfuncs import as_wires
 
 # ------------------------------------------------------------------------
@@ -77,7 +77,7 @@ class _MemReadBase(object):
 
     def __init__(self,  bitwidth, addrwidth, name, asynchronous, block):
         self.block = working_block(block)
-        name = next_tempvar_name(name)
+        name = wvIndexer.next_tempvar_name(name)
 
         if bitwidth <= 0:
             raise PyrtlError('bitwidth must be >= 1')
@@ -88,7 +88,7 @@ class _MemReadBase(object):
         self.name = name
         self.addrwidth = addrwidth
         self.readport_nets = []
-        self.id = next_memid()
+        self.id = wvIndexer.next_memid()
         self.asynchronous = asynchronous
 
     def __getitem__(self, item):

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -8,10 +8,10 @@ import numbers
 import collections
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
-from .core import working_block, PostSynthBlock
+from .core import working_block, PostSynthBlock, PythonSanitizer
 from .wire import Input, Register, Const, Output, WireVector
 from .memory import RomBlock
-from .helperfuncs import check_rtl_assertions, _currently_in_ipython, PythonSanitizer
+from .helperfuncs import check_rtl_assertions, _currently_in_ipython
 from .inputoutput import VerilogSanitizer
 
 # ----------------------------------------------------------------


### PR DESCRIPTION
Added `VerilogSanitizer` use in `print_vcd()`. Created `class WVIndexer(NameIndexer)` for use with WireVector and Memory internal names.