### PR TITLE
Removed NameIndexer-based classes from documentation

### DIFF
--- a/docs/rtllib/adders.rst
+++ b/docs/rtllib/adders.rst
@@ -1,4 +1,4 @@
-Input and Output
+Adders
 ================
 
 .. automodule:: pyrtl.rtllib.adders

--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -672,7 +672,7 @@ def set_debug_mode(debug=True):
 py_regex = '^[^\d\W]\w*\Z'
 
 
-class NameIndexer(object):
+class _NameIndexer(object):
     """ Provides internal names that are based on a prefix and an index"""
     def __init__(self, internal_prefix='_sani_temp'):
         self.internal_prefix = internal_prefix
@@ -689,14 +689,14 @@ class NameIndexer(object):
         pass
 
 
-class NameSanitizer(NameIndexer):
+class _NameSanitizer(_NameIndexer):
     """
     Sanitizes the names so that names can be used in places that don't allow
     for arbitrary names while not mangling valid names
 
     Put the values you want to validate into make_valid_string the first time
     you want to sanitize a particular string (or before the first time), and
-    retrieve from the NameSanitizer through indexing directly thereafter
+    retrieve from the _NameSanitizer through indexing directly thereafter
     eg: sani["__&sfhs"] for retrieval after the first time
 
     """
@@ -704,7 +704,7 @@ class NameSanitizer(NameIndexer):
         self.identifier = re.compile(identifier_regex_str)
         self.val_map = {}
         self.map_valid = map_valid_vals
-        super(NameSanitizer, self).__init__(internal_prefix)
+        super(_NameSanitizer, self).__init__(internal_prefix)
 
     def __getitem__(self, item):
         """ Get a value from the sanitizer"""
@@ -723,7 +723,7 @@ class NameSanitizer(NameIndexer):
         if not self.is_valid_str(string):
             if string in self.val_map:
                 raise IndexError("Value {} has already been given to the sanitizer".format(string))
-            internal_name = super(NameSanitizer, self).make_valid_string()
+            internal_name = super(_NameSanitizer, self).make_valid_string()
             self.val_map[string] = internal_name
             return internal_name
         else:
@@ -732,7 +732,7 @@ class NameSanitizer(NameIndexer):
             return string
 
 
-class PythonSanitizer(NameSanitizer):
+class PythonSanitizer(_NameSanitizer):
     """ Name Sanitizer specifically built for Python identifers"""
     def __init__(self, internal_prefix='_sani_temp', map_valid_vals=True):
         super(PythonSanitizer, self).__init__(py_regex, internal_prefix, map_valid_vals)

--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -684,6 +684,10 @@ class NameIndexer(object):
         self.internal_index += 1
         return internal_name
 
+    def next_indexed(self):
+        """ Pure virtual, will return wire, name, etc. """
+        pass
+
 
 class NameSanitizer(NameIndexer):
     """

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -14,7 +14,7 @@ from __future__ import print_function, unicode_literals
 import re
 import six
 
-from .core import working_block, NameIndexer
+from .core import working_block, _NameIndexer
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .wire import WireVector, Input, Output, Const, Register
 
@@ -106,10 +106,10 @@ def match_bitwidth(*args):
     return (wv.zero_extended(max_len) for wv in args)
 
 
-class ProbeIndexer(NameIndexer):
+class _ProbeIndexer(_NameIndexer):
     """ Provides indexed probe names for probe() """
     def __init__(self, internal_prefix='Probe'):
-        super(ProbeIndexer, self).__init__(internal_prefix)
+        super(_ProbeIndexer, self).__init__(internal_prefix)
         self.internal_index += 1
 
     def next_indexed(self, w, name):
@@ -130,7 +130,7 @@ class ProbeIndexer(NameIndexer):
         return w
 
 
-probeIndexer = ProbeIndexer()
+probeIndexer = _ProbeIndexer()
 
 
 def probe(w, name=None):
@@ -174,10 +174,10 @@ def get_stack(wire):
                ' to provide more information'
 
 
-class AssertIndexer(NameIndexer):
+class _AssertIndexer(_NameIndexer):
     """ Provides indexed assertion names for rtl_assert() """
     def __init__(self, internal_prefix='assertion'):
-        super(AssertIndexer, self).__init__(internal_prefix)
+        super(_AssertIndexer, self).__init__(internal_prefix)
         self.internal_index += 1
 
     def next_indexed(self, w):
@@ -185,7 +185,7 @@ class AssertIndexer(NameIndexer):
         self.internal_index += 1
         return res
 
-assertIndexer = AssertIndexer()
+assertIndexer = _AssertIndexer()
 
 
 def rtl_assert(w, exp, block=None):

--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -11,7 +11,7 @@ import re
 import collections
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
-from .core import working_block, NameSanitizer
+from .core import working_block, _NameSanitizer
 from .wire import WireVector, Input, Output, Const, Register
 from .corecircuits import concat
 
@@ -508,7 +508,7 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None):
 #
 
 
-class VerilogSanitizer(NameSanitizer):
+class VerilogSanitizer(_NameSanitizer):
     ver_regex = '[_A-Za-z][_a-zA-Z0-9\$]*$'
 
     _verilog_reserved = \

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -19,7 +19,7 @@ from . import core  # needed for _setting_keep_wirevector_call_stack,
 #                     _get_useful_callpoint_name()
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
-from .core import working_block, LogicNet, NameIndexer
+from .core import working_block, LogicNet, _NameIndexer
 
 # ----------------------------------------------------------------
 #        ___  __  ___  __   __
@@ -28,11 +28,11 @@ from .core import working_block, LogicNet, NameIndexer
 #
 
 
-class WVIndexer(NameIndexer):
+class _WVIndexer(_NameIndexer):
     """ Provides WireVector internal names and Memory ID's based on prefix and index """
     def __init__(self, internal_prefix='tmp'):
-        self.internal_prefix = internal_prefix
-        self.internal_index = 1
+        super(_WVIndexer, self).__init__(internal_prefix)
+        self.internal_index += 1
         self.internal_memid = 0
 
     def next_tempvar_name(self, name=None):
@@ -70,7 +70,7 @@ class WVIndexer(NameIndexer):
         return self.internal_memid
 
 
-wvIndexer = WVIndexer()
+wvIndexer = _WVIndexer()
 
 
 class WireVector(object):


### PR DESCRIPTION
Renamed `NameIndexer` and its children to have underscores before so they will not appear in the documentation, as they are internal classes.