### PR TITLE
Expanded functionality for `pyrtl.helperfuncs.wirevector_list()`: now accepting list arguments

### DIFF
--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -106,22 +106,70 @@ def check_rtl_assertions(sim):
 
 
 def input_list(names, bitwidth=1):
-    """ Allocate and return a list of Inputs. """
+    """ Allocate and return a list of Inputs.
+
+    :param string names: Comma- or space-separated list of names for the Inputs.
+    :param int bitwidth: The desired bitwidth for the resulting Inputs.
+    :return: List of Inputs.
+
+    Equivalent to: ::
+
+        wirevector_list(names, bitwidth, wvtype=pyrtl.wire.Input)
+
+    """
     return wirevector_list(names, bitwidth, wvtype=Input)
 
 
 def output_list(names, bitwidth=1):
-    """ Allocate and return a list of Outputs. """
+    """ Allocate and return a list of Outputs.
+
+    :param string names: Comma- or space-separated list of names for the Outputs.
+    :param int bitwidth: The desired bitwidth for the resulting Outputs.
+    :return: List of Outputs.
+
+    Equivalent to: ::
+
+        wirevector_list(names, bitwidth, wvtype=pyrtl.wire.Output)
+
+    """
     return wirevector_list(names, bitwidth, wvtype=Output)
 
 
 def register_list(names, bitwidth=1):
-    """ Allocate and return a list of Registers. """
+    """ Allocate and return a list of Registers.
+
+    :param string names: Comma- or space-separated list of names for the Registers.
+    :param int bitwidth: The desired bitwidth for the resulting Registers.
+    :return: List of Registers.
+
+    Equivalent to: ::
+
+        wirevector_list(names, bitwidth, wvtype=pyrtl.wire.Register)
+
+    """
     return wirevector_list(names, bitwidth, wvtype=Register)
 
 
 def wirevector_list(names, bitwidth=1, wvtype=WireVector):
-    """ Allocate and return a list of WireVectors. """
+    """ Allocate and return a list of WireVectors.
+
+    :param string names: Comma- or space-separated list of names for the WireVectors.
+    :param int bitwidth: The desired bitwidth for the resulting WireVectors.
+    :param WireVector wvtype: Which WireVector type to create.
+    :return: List of WireVectors.
+
+    Additionally, the ``names`` string can also contain an additional bitwidth specification
+    separated by a ``/`` in the name. This cannot be used in combination with a ``bitwidth``
+    value other than ``1``.
+
+    Examples: ::
+
+        wirevector_list('name1, name2, name3')
+        wirevector_list('input1 input2 input3', bitwidth=8, wvtype=pyrtl.wire.Input)
+        wirevector_list('output1, output2 output3', bitwidth=3, wvtype=pyrtl.wire.Output)
+        wirevector_list('two_bits/2, four_bits/4, eight_bits/8')
+
+    """
     if '/' in names and bitwidth != 1:
         raise PyrtlError('only one of optional "/" or bitwidth parameter allowed')
     names = names.replace(',', ' ')

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -184,8 +184,8 @@ def wirevector_list(names, bitwidth=None, wvtype=WireVector):
     if isinstance(bitwidth, numbers.Integral):
         bitwidth = [bitwidth]*len(names)
     if len(bitwidth) != len(names):
-        raise ValueError('number of names {n_names} should match len(bitwidths) {n_bws}'.format(n_names=len(names),
-                                                                                                n_bws=len(bitwidth)))
+        raise ValueError('number of names ' + str(len(names))
+                         + ' should match number of bitwidths ' + str(len(bitwidth)))
 
     wirelist = []
     for fullname, bw in zip(names, bitwidth):

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -180,7 +180,7 @@ def wirevector_list(names, bitwidth=1, wvtype=WireVector):
             name, bw = fullname.split('/')
         except:
             name, bw = fullname, bitwidth
-        wirelist.append(wvtype(bitwidth=bw, name=name))
+        wirelist.append(wvtype(bitwidth=int(bw), name=name))
     return wirelist
 
 

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -11,6 +11,42 @@ from pyrtl.rtllib import testingutils as utils
 
 # ---------------------------------------------------------------
 
+class TestWireVectorList(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_input_list_type(self):
+        inputs = pyrtl.helperfuncs.input_list('one, two, three')
+        self.assertTrue(all(isinstance(inp, pyrtl.Input) for inp in inputs))
+
+    def test_output_list_type(self):
+        outputs = pyrtl.helperfuncs.output_list('one, two, three')
+        self.assertTrue(all(isinstance(outp, pyrtl.Output) for outp in outputs))
+
+    def test_register_list_type(self):
+        registers = pyrtl.helperfuncs.register_list('one, two, three')
+        self.assertTrue(all(isinstance(reg, pyrtl.Register) for reg in registers))
+
+    def test_wirevector_list_type(self):
+        wirevectors = pyrtl.helperfuncs.wirevector_list('one, two, three')
+        self.assertTrue(all(isinstance(wire, pyrtl.WireVector) for wire in wirevectors))
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [1, 1, 1])
+
+    def test_wirevector_list_bitwidth(self):
+        wirevectors = pyrtl.helperfuncs.wirevector_list('one, two, three')
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [1, 1, 1])
+
+        wirevectors = pyrtl.helperfuncs.wirevector_list('one, two, three', 8)
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [8, 8, 8])
+
+    def test_wirevector_list_per_wire_width(self):
+        wirevectors = pyrtl.helperfuncs.wirevector_list('one/2, two/4, three/8')
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [2, 4, 8])
+
+        with self.assertRaises(pyrtl.PyrtlError):
+            pyrtl.helperfuncs.wirevector_list('one/2, two/4, three/8', 16)
+
+
 class TestPrettyPrinting(unittest.TestCase):
     def setUp(self):
         pass

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -28,6 +28,12 @@ class TestWireVectorList(unittest.TestCase):
         self.assertTrue(all(isinstance(reg, pyrtl.Register) for reg in registers))
 
     def test_wirevector_list_type(self):
+        # Single string of names
+        wirevectors = pyrtl.helperfuncs.wirevector_list('one, two, three')
+        self.assertTrue(all(isinstance(wire, pyrtl.WireVector) for wire in wirevectors))
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [1, 1, 1])
+
+        # List of names
         wirevectors = pyrtl.helperfuncs.wirevector_list('one, two, three')
         self.assertTrue(all(isinstance(wire, pyrtl.WireVector) for wire in wirevectors))
         self.assertListEqual([wire.bitwidth for wire in wirevectors], [1, 1, 1])
@@ -43,8 +49,19 @@ class TestWireVectorList(unittest.TestCase):
         wirevectors = pyrtl.helperfuncs.wirevector_list('one/2, two/4, three/8')
         self.assertListEqual([wire.bitwidth for wire in wirevectors], [2, 4, 8])
 
+        wirevectors = pyrtl.helperfuncs.wirevector_list(['one', 'two', 'three'], [2, 4, 8])
+        self.assertListEqual([wire.bitwidth for wire in wirevectors], [2, 4, 8])
+
+    def test_wirevector_list_raise_errors(self):
+
+        with self.assertRaises(ValueError):
+            pyrtl.helperfuncs.wirevector_list(['one', 'two', 'three'], [2, 4])
+
         with self.assertRaises(pyrtl.PyrtlError):
             pyrtl.helperfuncs.wirevector_list('one/2, two/4, three/8', 16)
+
+        with self.assertRaises(pyrtl.PyrtlError):
+            pyrtl.helperfuncs.wirevector_list(['one/2', 'two/4', 'three/8'], [8, 4, 2])
 
 
 class TestPrettyPrinting(unittest.TestCase):
@@ -463,7 +480,7 @@ class TestBasicMult(unittest.TestCase):
         product = pyrtl.Output(name="product")
         product <<= pyrtl.corecircuits._basic_mult(a, b)
 
-        self.assertEquals(len(product), len_a + len_b)
+        self.assertEqual(len(product), len_a + len_b)
 
         # creating the testing values and the correct results
         xvals = [int(random.uniform(0, 2**len_a-1)) for i in range(20)]
@@ -550,7 +567,7 @@ class TestRtlAssert(unittest.TestCase):
 
         sim = pyrtl.Simulation()
         sim.step({i: 1})
-        self.assertEquals(sim.inspect(o), 1)
+        self.assertEqual(sim.inspect(o), 1)
 
         with self.assertRaises(self.RTLSampleException):
             sim.step({i: 0})
@@ -561,7 +578,7 @@ class TestRtlAssert(unittest.TestCase):
 
         sim = pyrtl.FastSimulation()
         sim.step({i: 1})
-        self.assertEquals(sim.inspect(o), 1)
+        self.assertEqual(sim.inspect(o), 1)
 
         with self.assertRaises(self.RTLSampleException):
             sim.step({i: 0})


### PR DESCRIPTION
1. Added unittests and more elaborate docstrings for `wirevector_list` and derived functions
2. This includes a small bugfix: when custom bitwidths were passed using the `'name/bw'` syntax, they were passed on as string and not yet cast to integer.
3. `names` and `bitwidth` now also accept lists as input.
  - I kept the `'name/bw'` syntax intact, backwards compatibility is not broken.
  - Some additional unittests have been added for the new functionality