### PR TITLE
Improvements to step_multiple

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -272,7 +272,10 @@ class Simulation(object):
             raise PyrtlError('need to supply either input values or a number of steps to simulate')
 
         if len(provided_inputs) > 0:
-            msteps = len(list(provided_inputs.items())[0][1])
+            longest = sorted(list(provided_inputs.items()),
+                             key=lambda t: len(t[1]),
+                             reverse=True)[0]
+            msteps = len(longest[1])
             if nsteps:
                 if (nsteps > msteps):
                     raise PyrtlError('nsteps is specified but is greater than the '
@@ -601,7 +604,10 @@ class FastSimulation(object):
             raise PyrtlError('need to supply either input values or a number of steps to simulate')
 
         if len(provided_inputs) > 0:
-            msteps = len(list(provided_inputs.items())[0][1])
+            longest = sorted(list(provided_inputs.items()),
+                             key=lambda t: len(t[1]),
+                             reverse=True)[0]
+            msteps = len(longest[1])
             if nsteps:
                 if (nsteps > msteps):
                     raise PyrtlError('nsteps is specified but is greater than the '

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -217,15 +217,17 @@ class Simulation(object):
         # raise the appropriate exceptions
         check_rtl_assertions(self)
 
-    def step_multiple(self, provided_inputs, expected_outputs=None, stop_after_first_error=False):
+    def step_multiple(self, provided_inputs, expected_outputs=None,
+                      file=sys.stdout, stop_after_first_error=False):
         """ Take the simulation forward N cycles, where N is the number of values
          for each provided input.
 
         :param provided_inputs: a dictionary mapping wirevectors to their values for N steps
         :param expected_outputs: a dictionary mapping wirevectors to their expected values
             for N steps
+        :param file: where to write the output (if there are unexpected outputs detected)
         :param stop_after_first_error: a boolean flag indicating whether to stop the simulation
-            after encountering the first error (defaults to False)
+            after the step where the first errors are encountered (defaults to False)
 
         All input wires must be in the provided_inputs in order for the simulation
         to accept these values. Additionally, the length of the array of provided values for each
@@ -271,14 +273,27 @@ class Simulation(object):
                     actual = self.inspect(expvar)
                     if expected != actual:
                         failed.append((i, expvar, expected, actual))
-                        if stop_after_first_error:
-                            break
+
+            if failed and stop_after_first_error:
+                break
 
         if failed:
-            print("{0:>5} {1:>10} {2:>8} {3:>8}".format("step", "name", "expected", "actual"))
-            for (step, name, expected, actual) in failed:
-                print("{0:>5} {1:>10} {2:>8} {3:>8}".format(step, name, expected, actual))
-            print()
+            if stop_after_first_error:
+                s = "(stopped after step with first error):"
+            else:
+                s = "on one or more steps:"
+            file.write("Unexpected output " + s + "\n")
+            file.write("{0:>5} {1:>10} {2:>8} {3:>8}\n"
+                       .format("step", "name", "expected", "actual"))
+
+            def _sort_tuple(t):
+                # Sort by step and then wire name
+                return (t[0], _trace_sort_key(t[1]))
+
+            failed_sorted = sorted(failed, key=_sort_tuple)
+            for (step, name, expected, actual) in failed_sorted:
+                file.write("{0:>5} {1:>10} {2:>8} {3:>8}\n".format(step, name, expected, actual))
+            file.flush()
 
     def inspect(self, w):
         """ Get the value of a wirevector in the last simulation cycle.
@@ -500,6 +515,84 @@ class FastSimulation(object):
 
         # check the rtl assertions
         check_rtl_assertions(self)
+
+    def step_multiple(self, provided_inputs, expected_outputs=None,
+                      file=sys.stdout, stop_after_first_error=False):
+        """ Take the simulation forward N cycles, where N is the number of values
+         for each provided input.
+
+        :param provided_inputs: a dictionary mapping wirevectors to their values for N steps
+        :param expected_outputs: a dictionary mapping wirevectors to their expected values
+            for N steps
+        :param file: where to write the output (if there are unexpected outputs detected)
+        :param stop_after_first_error: a boolean flag indicating whether to stop the simulation
+            after the step where the first errors are encountered (defaults to False)
+
+        All input wires must be in the provided_inputs in order for the simulation
+        to accept these values. Additionally, the length of the array of provided values for each
+        input must be the same.
+
+        Example: if we have inputs named 'a' and 'b' and output 'o', we can call:
+        sim.step_multiple({'a': [0,1], 'b': [23,32]}, {'o': [42, 43]}) to simulate 2 cycles,
+        where in the first cycle 'a' and 'b' take on 0 and 23, respectively, and 'o' is expected to
+        have the value 42, and in the second cycle 'a' and 'b' take on 1 and 32, respectively, and
+        'o' is expected to have the value 43.
+
+        If your values are all single digit, you can also specify them in a single string, e.g.
+        sim.step_multiple({'a': '01', 'b': '01'}) will simulate 2 cycles, with 'a' and 'b' taking on
+        0 and 0, respectively, on the first cycle and '1' and '1', respectively, on the second
+        cycle.
+        """
+        if len(provided_inputs) == 0:
+            return
+
+        if len(list(provided_inputs.items())[0]) < 2:
+            raise PyrtlError('no input values supplied for wire "%s"'
+                             % (provided_inputs.items()[0][0]))
+
+        nsteps = len(list(provided_inputs.items())[0][1])
+
+        if list(filter(lambda l: len(l) != nsteps, provided_inputs.values())):
+            raise PyrtlError(
+                "must supply a value for each provided wire "
+                "for each step of simulation")
+
+        if expected_outputs and list(filter(lambda l: len(l) != nsteps, expected_outputs.values())):
+            raise PyrtlError(
+                "any expected outputs must have a supplied value "
+                "each step of simulation")
+
+        failed = []
+        for i in range(nsteps):
+            self.step({w: int(v[i]) for w, v in provided_inputs.items()})
+
+            if expected_outputs is not None:
+                for expvar in expected_outputs.keys():
+                    expected = int(expected_outputs[expvar][i])
+                    actual = self.inspect(expvar)
+                    if expected != actual:
+                        failed.append((i, expvar, expected, actual))
+
+            if failed and stop_after_first_error:
+                break
+
+        if failed:
+            if stop_after_first_error:
+                s = "(stopped after step with first error):"
+            else:
+                s = "on one or more steps:"
+            file.write("Unexpected output " + s + "\n")
+            file.write("{0:>5} {1:>10} {2:>8} {3:>8}\n"
+                       .format("step", "name", "expected", "actual"))
+
+            def _sort_tuple(t):
+                # Sort by step and then wire name
+                return (t[0], _trace_sort_key(t[1]))
+
+            failed_sorted = sorted(failed, key=_sort_tuple)
+            for (step, name, expected, actual) in failed_sorted:
+                file.write("{0:>5} {1:>10} {2:>8} {3:>8}\n".format(step, name, expected, actual))
+            file.flush()
 
     def inspect(self, w):
         """ Get the value of a wirevector in the last simulation cycle.

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -302,6 +302,113 @@ class SimInputValidationBase(unittest.TestCase):
             sim_trace = pyrtl.SimulationTrace()
 
 
+class SimStepMultipleBase(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+        in1 = pyrtl.Input(4, "in1")
+        in2 = pyrtl.Input(4, "in2")
+        out1 = pyrtl.Output(4, "out1")
+        out1 <<= (in1 ^ in2) + pyrtl.Const(1)
+        out2 = pyrtl.Output(4, "out2")
+        out2 <<= in1 | in2
+        self.inputs = {
+            'in1': [0, 1, 3, 15, 14],
+            'in2': [6, 6, 6, 6, 6],
+        }
+
+    def test_step_multiple_no_expected_check(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        sim.step_multiple(self.inputs)
+
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1   0  1  3 15 14\n"
+                          "in2   6  6  6  6  6\n"
+                          "out1  7  8  6 10  9\n"
+                          "out2  6  7  7 15 14\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+    def test_step_multiple_no_errors(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        expected = {
+            'out1': [7, 8, 6, 10, 9],
+            'out2': [6, 7, 7, 15, 14],
+        }
+        sim.step_multiple(self.inputs, expected)
+
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1   0  1  3 15 14\n"
+                          "in2   6  6  6  6  6\n"
+                          "out1  7  8  6 10  9\n"
+                          "out2  6  7  7 15 14\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+    def test_step_multiple_many_errors_report_only_first(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        expected = {
+            'out1': [7, 9, 4, 10, 9],
+            'out2': [6, 2, 7, 8, 14],
+        }
+        output = six.StringIO()
+        sim.step_multiple(self.inputs, expected, file=output, stop_after_first_error=True)
+
+        # Test the output about unexpected values
+        correct_output = ("Unexpected output (stopped after step with first error):\n"
+                          " step       name expected   actual\n"
+                          "    1       out1        9        8\n"
+                          "    1       out2        2        7\n")
+        self.assertEqual(output.getvalue(), correct_output)
+
+        # Test that the trace stopped after the step with the first error
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1  0 1\n"
+                          "in2  6 6\n"
+                          "out1 7 8\n"
+                          "out2 6 7\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+    def test_step_multiple_many_errors_report_all(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        expected = {
+            'out1': [7, 9, 4, 10, 9],
+            'out2': [6, 2, 7, 8, 14],
+        }
+        output = six.StringIO()
+        sim.step_multiple(self.inputs, expected, file=output)
+
+        # Test the output about unexpected values
+        correct_output = ("Unexpected output on one or more steps:\n"
+                          " step       name expected   actual\n"
+                          "    1       out1        9        8\n"
+                          "    1       out2        2        7\n"
+                          "    2       out1        4        6\n"
+                          "    3       out2        8       15\n")
+        self.assertEqual(output.getvalue(), correct_output)
+
+        # Test that the trace still produced all the steps
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1   0  1  3 15 14\n"
+                          "in2   6  6  6  6  6\n"
+                          "out1  7  8  6 10  9\n"
+                          "out2  6  7  7 15 14\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+
 class TraceWithAdderBase(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()


### PR DESCRIPTION
These commits add several unit tests to cover both normal flow and error edge cases of 'step_multiple', fixes some bugs revealed in the process, adds additional functionality (like being able to stop simulation after the first encountered error, or specifying the number of steps to simulate independent of given input values), and adds 'step_multiple' to 'compilesim.py'. It may be that this function can be extracted into one helper function that is shared amongst Simulation, FastSimulation, and CompiledSimulation (passing in various inspect and step functions as arguments to make it shareable) but that can be left for another day. Right now the format matches how the *Simulation classes are currently defined.