### PR TITLE
Add ability to get handle to internally-defined memories (for use in Simulation) (Version 2)

### DIFF
--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -302,29 +302,29 @@ class SimInputValidationBase(unittest.TestCase):
             sim_trace = pyrtl.SimulationTrace()
 
 
-class SimStepExternal(unittest.TestCase):
-
-    """ Function for testing with """
-    @staticmethod
-    @pyrtl.simulation.external('mem')
-    def special_memory(read_addr, write_addr, data, wen):
-        mem = pyrtl.MemBlock(bitwidth=32, addrwidth=5)
-        mem[write_addr] <<= pyrtl.MemBlock.EnabledWrite(data, wen & (write_addr > 0))
-        return mem[read_addr]
+class SimStepExternalBase(unittest.TestCase):
 
     def setUp(self):
         pyrtl.reset_working_block()
 
     def test_step_with_externalized_mem(self):
+
+        @pyrtl.simulation.external('mem')
+        def special_memory(read_addr, write_addr, data, wen):
+            """ Function for testing external memory access with """
+            mem = pyrtl.MemBlock(bitwidth=32, addrwidth=5)
+            mem[write_addr] <<= pyrtl.MemBlock.EnabledWrite(data, wen & (write_addr > 0))
+            return mem[read_addr]
+
         read_addr = pyrtl.Input(5, 'read_addr')
         write_addr = pyrtl.Input(5, 'write_addr')
         data = pyrtl.Input(32, 'data')
         wen = pyrtl.Input(1, 'wen')
         res = pyrtl.Output(32, 'res')
 
-        res <<= SimStepExternal.special_memory(read_addr, write_addr, data, wen)
+        res <<= special_memory(read_addr, write_addr, data, wen)
         sim = pyrtl.Simulation(memory_value_map={
-            SimStepExternal.special_memory.mem: {
+            special_memory.mem: {
                 0: 5,
                 1: 6,
                 2: 7,
@@ -346,7 +346,7 @@ class SimStepExternal(unittest.TestCase):
         sim.step_multiple(inputs, expected)
 
         # Let's check the memory contents too
-        mem_map = sim.inspect_mem(SimStepExternal.special_memory)
+        mem_map = sim.inspect_mem(special_memory.mem)
         self.assertEqual(mem_map[0], 5)
         self.assertEqual(mem_map[1], 9)
         self.assertEqual(mem_map[2], 0)


### PR DESCRIPTION
This adds the ability to get a reference to a memory created internally to any function/block.

This useful for when a block defines its own internal memory block, and during simulation you want to instantiate that memory with certain values for testing. Since the Simulation constructor requires a reference to the memory object itself, but the block your testing defines the memory internally, it's not possible get it without making that local variable an attribute of the function. This decorator does this **automagically** for you.

This version uses Python introspection in order to work. [Another pull request](https://github.com/UCSBarchlab/PyRTL/pull/278) manipulates the working block in order to store and get these memory block references. This pull request is intended to be a discussion on 1) if this is useful (I think it is) and 2) which way (this pull request or [that one](https://github.com/UCSBarchlab/PyRTL/pull/278)) is a better approach.

The one advantage is that you don't need to name your internal memories to access them (unlike the other pull request), so no need to mess with internal block code.
        
            import pyrtl
            from pyrtl.simulation import external

            @external('mem')   # <======= New stuff
            def special_memory(read_addr, write_addr, data, wen):
                mem = pyrtl.MemBlock(bitwidth=32, addrwidth=5)
                mem[write_addr] <<= pyrtl.MemBlock.EnabledWrite(data, wen & (write_addr > 0))
                return mem[read_addr]

            read_addr = pyrtl.Input(5, 'read_addr')
            write_addr = pyrtl.Input(5, 'write_addr')
            data = pyrtl.Input(32, 'data')
            wen = pyrtl.Input(1, 'wen')
            res = pyrtl.Output(32, 'res')
            
            res <<= special_memory(read_addr, write_addr, data, wen)
            sim = pyrtl.Simulation(memory_value_map={
                special_memory.mem: {  # <===== New stuff
                    0: 5,
                    1: 6,
                    2: 7,
                }
            })

            inputs = {
                'read_addr':  '012012',
                'write_addr': '012012',
                'data':       '890333',
                'wen':        '111000',
            }
            expected = {
                'res': '567590',
            }
            sim.step_multiple(inputs, expected)
