### PR TITLE
Add ability to get handle to internally-defined memories (for use in Simulation) (Version 1)

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -262,7 +262,7 @@ class Block(object):
         # pre-synthesis wirevectors to post-synthesis vectors
         self.legal_ops = set('w~&|^n+-*<>=xcsrm@')  # set of legal OPS
         self.rtl_assert_dict = {}   # map from wirevectors -> exceptions, used by rtl_assert
-        self.memblocks_by_name = {}  # map from name->memblock, for easy access to memblock objs
+        self.memblock_by_name = {}  # map from name->memblock, for easy access to memblock objs
 
     def __str__(self):
         """String form has one LogicNet per line."""
@@ -307,7 +307,7 @@ class Block(object):
         (e.g. for instantiating during a simulation).
         """
         self.sanity_check_memblock(mem)
-        self.memblocks_by_name[mem.name] = mem
+        self.memblock_by_name[mem.name] = mem
 
     def get_memblock_by_name(self, name, strict=False):
         """ Get a reference to a memory stored in this block by name.
@@ -362,8 +362,8 @@ class Block(object):
             }
             sim.step_multiple(inputs, expected)
         """
-        if name in self.memblocks_by_name:
-            return self.memblocks_by_name[name]
+        if name in self.memblock_by_name:
+            return self.memblock_by_name[name]
         elif strict:
             raise PyrtlError('error, block does not have a memblock named %s' % name)
         else:

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -105,7 +105,7 @@ class _MemReadBase(object):
         self.readport_nets = []
         self.id = _memIndex.next_index()
         self.asynchronous = asynchronous
-        self.block._add_mem_block(self)
+        self.block._add_memblock(self)
 
     def __getitem__(self, item):
         """ Builds circuitry to retrieve an item from the memory """

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -105,6 +105,7 @@ class _MemReadBase(object):
         self.readport_nets = []
         self.id = _memIndex.next_index()
         self.asynchronous = asynchronous
+        self.block._add_mem_block(self)
 
     def __getitem__(self, item):
         """ Builds circuitry to retrieve an item from the memory """

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -597,14 +597,6 @@ class Const(WireVector):
             "aka they cannot have other wires driving it"
             % str(self.name))
 
-class Bit(WireVector):
-    """ A WireVector of length 1
-
-    A convenience class that is equivalent to doing WireVector(bitwidth=1).
-    """
-
-    def __init__(self, name='', block=None):
-        super(Bit, self).__init__(1, name, block)
 
 class Register(WireVector):
     """ A WireVector with a register state element embedded.

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -597,6 +597,14 @@ class Const(WireVector):
             "aka they cannot have other wires driving it"
             % str(self.name))
 
+class Bit(WireVector):
+    """ A WireVector of length 1
+
+    A convenience class that is equivalent to doing WireVector(bitwidth=1).
+    """
+
+    def __init__(self, name='', block=None):
+        super(Bit, self).__init__(1, name, block)
 
 class Register(WireVector):
     """ A WireVector with a register state element embedded.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,16 +85,26 @@ class TestBlock(unittest.TestCase):
         for net in block.logic:
             print(net)
 
-    def test_no_mem_blocks(self):
-        pyrtl.reset_working_block()
+    def test_no_memblocks(self):
         block = pyrtl.working_block()
-        self.assertFalse(block.mem_blocks)
+        self.assertFalse(block.memblocks_by_name)
 
-    def test_bad_mem_block_name(self):
-        pyrtl.reset_working_block()
+    def test_bad_memblock_name(self):
         block = pyrtl.working_block()
         with self.assertRaises(KeyError):
             _ = block.get_mem_block_by_name('bad_mem')
+
+    def test_same_memblock_referenced_across_multiple_operators(self):
+        mem_name = 'mem'
+        mem = pyrtl.MemBlock(32, 5, mem_name)
+        x = mem[0]
+        mem[1] <<= 42
+        mem = pyrtl.working_block().get_memblock_by_name(mem_name)
+        for net in pyrtl.working_block().logic:
+            if net.op == 'm':
+                self.assertIs(net.op_param[1], mem)
+            if net.op == '@':
+                self.assertIs(net.op_param[1], mem)
 
 
 class TestSanityCheckNet(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,6 +85,17 @@ class TestBlock(unittest.TestCase):
         for net in block.logic:
             print(net)
 
+    def test_no_mem_blocks(self):
+        pyrtl.reset_working_block()
+        block = pyrtl.working_block()
+        self.assertFalse(block.mem_blocks)
+
+    def test_bad_mem_block_name(self):
+        pyrtl.reset_working_block()
+        block = pyrtl.working_block()
+        with self.assertRaises(KeyError):
+            _ = block.get_mem_block_by_name['bad_mem']
+
 
 class TestSanityCheckNet(unittest.TestCase):
     def setUp(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,10 +89,15 @@ class TestBlock(unittest.TestCase):
         block = pyrtl.working_block()
         self.assertFalse(block.memblocks_by_name)
 
-    def test_bad_memblock_name(self):
+    def test_bad_memblock_name_strict(self):
         block = pyrtl.working_block()
-        with self.assertRaises(KeyError):
-            _ = block.get_mem_block_by_name('bad_mem')
+        with self.assertRaises(pyrtl.PyrtlError):
+            _ = block.get_memblock_by_name('bad_mem', strict=True)
+
+    def test_bad_memblock_name_none(self):
+        block = pyrtl.working_block()
+        mem = block.get_memblock_by_name('bad_mem')
+        self.assertIsNone(mem)
 
     def test_same_memblock_referenced_across_multiple_operators(self):
         mem_name = 'mem'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,7 +94,7 @@ class TestBlock(unittest.TestCase):
         pyrtl.reset_working_block()
         block = pyrtl.working_block()
         with self.assertRaises(KeyError):
-            _ = block.get_mem_block_by_name['bad_mem']
+            _ = block.get_mem_block_by_name('bad_mem')
 
 
 class TestSanityCheckNet(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -87,7 +87,7 @@ class TestBlock(unittest.TestCase):
 
     def test_no_memblocks(self):
         block = pyrtl.working_block()
-        self.assertFalse(block.memblocks_by_name)
+        self.assertFalse(block.memblock_by_name)
 
     def test_bad_memblock_name_strict(self):
         block = pyrtl.working_block()

--- a/tests/test_memblock.py
+++ b/tests/test_memblock.py
@@ -90,11 +90,15 @@ class RTLMemBlockDesignBase(unittest.TestCase):
         with self.assertRaises(pyrtl.PyrtlError):
             lim_memory[self.mem_write_address] <<= pyrtl.Const(6)
 
-    def test_mem_block_added(self):
+    def test_memblock_added_user_named(self):
         mem_name = 'small_memory'
         small_memory = pyrtl.MemBlock(bitwidth=self.bitwidth, addrwidth=self.addrwidth,
                                       name=mem_name, max_read_ports=2, max_write_ports=1)
-        self.assertIs(pyrtl.working_block().get_mem_block_by_name(mem_name), small_memory)
+        self.assertIs(pyrtl.working_block().get_memblock_by_name(mem_name), small_memory)
+
+    def test_memblock_added_default_named(self):
+        mem = pyrtl.MemBlock(32, 8)
+        self.assertIs(pyrtl.working_block().get_memblock_by_name(mem.name), mem)
 
 
 class MemIndexedTests(unittest.TestCase):

--- a/tests/test_memblock.py
+++ b/tests/test_memblock.py
@@ -90,6 +90,12 @@ class RTLMemBlockDesignBase(unittest.TestCase):
         with self.assertRaises(pyrtl.PyrtlError):
             lim_memory[self.mem_write_address] <<= pyrtl.Const(6)
 
+    def test_mem_block_added(self):
+        mem_name = 'small_memory'
+        small_memory = pyrtl.MemBlock(bitwidth=self.bitwidth, addrwidth=self.addrwidth,
+                                      name=mem_name, max_read_ports=2, max_write_ports=1)
+        self.assertIs(pyrtl.working_block().get_mem_block_by_name[mem_name], small_memory)
+
 
 class MemIndexedTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_memblock.py
+++ b/tests/test_memblock.py
@@ -94,7 +94,7 @@ class RTLMemBlockDesignBase(unittest.TestCase):
         mem_name = 'small_memory'
         small_memory = pyrtl.MemBlock(bitwidth=self.bitwidth, addrwidth=self.addrwidth,
                                       name=mem_name, max_read_ports=2, max_write_ports=1)
-        self.assertIs(pyrtl.working_block().get_mem_block_by_name[mem_name], small_memory)
+        self.assertIs(pyrtl.working_block().get_mem_block_by_name(mem_name), small_memory)
 
 
 class MemIndexedTests(unittest.TestCase):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -322,7 +322,7 @@ class SimStepAccessInternalMemoryBase(unittest.TestCase):
         res <<= special_memory(read_addr, write_addr, data, wen)
 
         # Can only access it after the `special_memory` block has been instantiated/called
-        special_mem = pyrtl.working_block().get_mem_block_by_name('special_mem')
+        special_mem = pyrtl.working_block().get_memblock_by_name('special_mem')
 
         sim = self.sim(memory_value_map={
             special_mem: {

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -301,6 +301,57 @@ class SimInputValidationBase(unittest.TestCase):
         with self.assertRaises(pyrtl.PyrtlError):
             sim_trace = pyrtl.SimulationTrace()
 
+class SimStepAccessInternalMemoryBase(unittest.TestCase):
+
+     def setUp(self):
+        pyrtl.reset_working_block()
+
+     def test_step_with_internal_memory(self):
+
+        def special_memory(read_addr, write_addr, data, wen):
+            mem = pyrtl.MemBlock(bitwidth=32, addrwidth=5, name='special_mem')
+            mem[write_addr] <<= pyrtl.MemBlock.EnabledWrite(data, wen & (write_addr > 0))
+            return mem[read_addr]
+
+        read_addr = pyrtl.Input(5, 'read_addr')
+        write_addr = pyrtl.Input(5, 'write_addr')
+        data = pyrtl.Input(32, 'data')
+        wen = pyrtl.Input(1, 'wen')
+        res = pyrtl.Output(32, 'res')
+
+        res <<= special_memory(read_addr, write_addr, data, wen)
+
+        # Can only access it after the `special_memory` block has been instantiated/called
+        special_mem = pyrtl.working_block().get_mem_block_by_name('special_mem')
+
+        sim = self.sim(memory_value_map={
+            special_mem: {
+                0: 5,
+                1: 6,
+                2: 7,
+                3: 8,
+            }
+        })
+
+        inputs = {
+            'read_addr':  '012012',
+            'write_addr': '012012',
+            'data':       '890333',
+            'wen':        '111000',
+        }
+        expected = {
+            'res': '567590',
+        }
+        # This should not fail
+        sim.step_multiple(inputs, expected)
+
+         # Let's check the memory contents too
+        mem_map = sim.inspect_mem(special_mem)
+        self.assertEqual(mem_map[0], 5)
+        self.assertEqual(mem_map[1], 9)
+        self.assertEqual(mem_map[2], 0)
+        self.assertEqual(mem_map[3], 8)
+
 
 class SimStepMultipleBase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This adds the ability to get a reference to a memory created internally to any function/block (as long as you have its name)

This useful for when a block defines its own internal memory block, and during simulation you want to instantiate that memory with certain values for testing. Since the Simulation constructor requires a reference to the memory object itself, but the block your testing defines the memory internally, this allows you to get the object reference.

Note that this requires you know the name of the memory block, meaning that you most likely need to have named it yourself.

This version manipulates the working block in order to store and get these memory block references. [Another pull request](https://github.com/UCSBarchlab/PyRTL/pull/277) uses Python introspection and a decorator instead and thus doesn't mess with any of the internals of PyRTL. This pull request is intended to be a discussion on 1) if this is useful (I think it is) and 2) which way (this pull request or [that one](https://github.com/UCSBarchlab/PyRTL/pull/277)) is a better approach.
        
           def special_memory(read_addr, write_addr, data, wen):
                mem = pyrtl.MemBlock(bitwidth=32, addrwidth=5, name='special_mem')
                mem[write_addr] <<= pyrtl.MemBlock.EnabledWrite(data, wen & (write_addr > 0))
                return mem[read_addr]

            read_addr = pyrtl.Input(5, 'read_addr')
            write_addr = pyrtl.Input(5, 'write_addr')
            data = pyrtl.Input(32, 'data')
            wen = pyrtl.Input(1, 'wen')
            res = pyrtl.Output(32, 'res')

            res <<= special_memory(read_addr, write_addr, data, wen)

            # Can only access it after the `special_memory` block has been instantiated/called
            # New stuff =====V
            special_mem = pyrtl.working_block().get_mem_block_by_name('special_mem')

            sim = pyrtl.Simulation(memory_value_map={
                special_mem: {
                    0: 5,
                    1: 6,
                    2: 7,
                }
            })

            inputs = {
                'read_addr':  '012012',
                'write_addr': '012012',
                'data':       '890333',
                'wen':        '111000',
            }
            expected = {
                'res': '567590',
            }
            sim.step_multiple(inputs, expected)
