### PR TITLE
small adjustment to rendered trace, so that it doesn't print leading spaces when trace_list is specified with shorter wire names

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -799,7 +799,7 @@ class FastSimulation(object):
             elif net.op == 'c':
                 expr = ''
                 for i in range(len(net.args)):
-                    if expr is not '':
+                    if expr != '':
                         expr += ' | '
                     shiftby = sum(len(j) for j in net.args[i+1:])
                     expr += shift(self._arg_varname(net.args[i]), '<<', shiftby)
@@ -1135,12 +1135,11 @@ class SimulationTrace(object):
         :param symbol_len: The "length" of each rendered cycle in characters.
         :param segment_size: Traces are broken in the segments of this number of cycles.
         :param segment_delim: The character to be output between segments.
-        :param extra_line: A Boolean to determin if we should print a blank line between signals.
+        :param extra_line: A Boolean to determine if we should print a blank line between signals.
 
         The resulting output can be viewed directly on the terminal or looked
         at with "more" or "less -R" which both should handle the ASCII escape
-        sequences used in rendering. render_trace takes the following optional
-        arguments.
+        sequences used in rendering.
         """
         if _currently_in_ipython():
             from IPython.display import display, HTML, Javascript  # pylint: disable=import-error
@@ -1197,7 +1196,7 @@ class SimulationTrace(object):
         # print the 'ruler' which is just a list of 'ticks'
         # mapped by the pretty map
 
-        maxnamelen = max(len(w) for w in self.trace)
+        maxnamelen = max(len(w) for w in trace_list)
         maxtracelen = max(len(v) for v in self.trace.values())
         if segment_size is None:
             segment_size = maxtracelen


### PR DESCRIPTION
Before this change, the `render_trace()` method would print leading spaces before the trace based on the length of the longest wire name, even if that wire wasn't included in the outputted trace. This fix bases the number of leading spaces on the trace_list. It's safe to use the trace_list because is made sure to be set in line 1188.

Given
```
sim.tracer.render_trace(symbol_len=6, trace_list=['reset', 'data_in', 'valid_in', 'ready_in', 'data_out', 'valid_out', 'ready_out'])
```

Before change:
<img width="977" alt="Screen Shot 2020-06-09 at 12 08 48 AM" src="https://user-images.githubusercontent.com/2482771/84118529-f91a2080-a9e7-11ea-8b80-a7daed2c0179.png">


After change:
<img width="817" alt="Screen Shot 2020-06-09 at 12 08 58 AM" src="https://user-images.githubusercontent.com/2482771/84118542-fd463e00-a9e7-11ea-8065-e01be6cb9a6c.png">

Also made sure if still works if no trace_list is specified.

Given
```
sim.tracer.render_trace()
```

it emits

<img width="863" alt="Screen Shot 2020-06-09 at 12 26 49 AM" src="https://user-images.githubusercontent.com/2482771/84118583-0a632d00-a9e8-11ea-833c-16d460bc1516.png">

(Also minor clean up in comparison in line 802; Python continually complained whenever I run code from this file prior to that fix).