### PR TITLE
fix access to debug_mode global variable, silence Probe stack info when not in debug mode

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -747,6 +747,8 @@ debug_mode = False
 _setting_keep_wirevector_call_stack = False
 _setting_slower_but_more_descriptive_tmps = False
 
+def _get_debug_mode():
+    return debug_mode
 
 def _get_useful_callpoint_name():
     """ Attempts to find the lowest user-level call into the pyrtl module

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -8,7 +8,7 @@ import math
 import numbers
 import six
 
-from .core import working_block, _NameIndexer
+from .core import working_block, _NameIndexer, _get_debug_mode
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .wire import WireVector, Input, Output, Const, Register
 
@@ -34,11 +34,11 @@ def probe(w, name=None):
     into ``y <<= probe(x)[0:3] + 4`` to give visibility into both the origin of
     ``x`` (including the line that WireVector was originally created) and
     the run-time values of ``x`` (which will be named and thus show up by
-    default in a trace.  Likewise ``y <<= probe(x[0:3]) + 4``,
+    default in a trace).  Likewise ``y <<= probe(x[0:3]) + 4``,
     ``y <<= probe(x[0:3] + 4)``, and ``probe(y) <<= x[0:3] + 4`` are all
     valid uses of `probe`.
 
-    Note: `probe` does actually add a wire to the working block of w (which can
+    Note: `probe` does actually add an Output wire to the working block of w (which can
     confuse various post-processing transforms such as output to verilog).
     """
     if not isinstance(w, WireVector):
@@ -46,7 +46,8 @@ def probe(w, name=None):
 
     if name is None:
         name = '(%s: %s)' % (probeIndexer.make_valid_string(), w.name)
-    print("Probe: " + name + ' ' + get_stack(w))
+    if _get_debug_mode():
+        print("Probe: " + name + ' ' + get_stack(w))
 
     p = Output(name=name)
     p <<= w  # late assigns len from w automatically

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -158,7 +158,7 @@ def _constant_prop_pass(block, silence_unexpected_net_warnings=False):
 
         num_constants = sum((isinstance(arg, Const) for arg in net_checking.args))
 
-        if num_constants is 0 or net_checking.op in no_optimization_ops:
+        if num_constants == 0 or net_checking.op in no_optimization_ops:
             return  # assuming wire nets are already optimized
 
         if (net_checking.op in two_var_ops) and num_constants == 1:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -6,7 +6,7 @@ ways to change a block.
 
 from __future__ import print_function, unicode_literals
 
-from .core import working_block, set_working_block, debug_mode, LogicNet, PostSynthBlock
+from .core import working_block, set_working_block, _get_debug_mode, LogicNet, PostSynthBlock
 from .helperfuncs import _NetCount
 from .corecircuits import (_basic_mult, _basic_add, _basic_sub, _basic_eq,
                            _basic_lt, _basic_gt, _basic_select, concat_list,
@@ -41,13 +41,13 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
         block = copy_block(block)
 
     with set_working_block(block, no_sanity_check=True):
-        if (not skip_sanity_check) or debug_mode:
+        if (not skip_sanity_check) or _get_debug_mode():
             block.sanity_check()
         _remove_wire_nets(block)
         constant_propagation(block, True)
         _remove_unlistened_nets(block)
         common_subexp_elimination(block)
-        if (not skip_sanity_check) or debug_mode:
+        if (not skip_sanity_check) or _get_debug_mode():
             block.sanity_check()
     return block
 


### PR DESCRIPTION
There are two semi-related changes here, the first of which is (hopefully) uncontroversial, and a third minor change.


## First change
The first changes references to `debug_mode` outside of `core.py` to be function calls (and adds a new function `_get_debug_mode()` for calling). This is needed because when a global variable is imported like `from .core import debug_mode`, a new copy of that variable is created for just that module, i.e.

```
from .core import debug_mode
```

is the same as
```
import core
debug_mode = core.debug_mode
```

We can't just replace `debug_mode` with `core.debug_mode` because `import core` is illegal syntax in this case. Please let me know if there's a better way of doing this.

I tested this by observing that given the following code:

```
pyrtl.set_debug_mode(debug=True)
...
pyrtl.optimize(skip_sanity_check=True)
```

it skipped the sanity check in [line 45](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:probe-verbose?expand=1#diff-e791de323bb44e93d2971304345da760R45) when I wouldn't have expected it to (verified via a debugger). Adding this diff's changes fixes that.

## Second change

I often add probes to my design to inspect internal wires (without the intention of ever seeing their stack trace). However, PyRTL always reminds the user in these cases that "No call info found for wire. use set_debug_mode() to provide more information" (for each of my probed wires). I feel like it would be acceptable to silence this message and only display it if `debug_mode` is on.

I.e. go from
<img width="1176" alt="Screen Shot 2020-06-09 at 1 47 53 AM" src="https://user-images.githubusercontent.com/2482771/84126874-56679f00-a9f3-11ea-8153-2b3812ed269c.png">


to

<img width="1164" alt="Screen Shot 2020-06-09 at 1 48 10 AM" src="https://user-images.githubusercontent.com/2482771/84126882-5a93bc80-a9f3-11ea-8878-0785da027ccd.png">


## Third change
As I was already editing the file, Python complained about the operator used in a comparison. No functionality has changed, though it's a little more future-proof now.