### PR TITLE
print wire names in error when they are inputs or outputs are misused

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -641,12 +641,14 @@ class Block(object):
                 raise PyrtlInternalError('error, net with unknown source "%s"' % w.name)
 
         # checks that input and output wirevectors are not misused
-        for w in net.dests:
-            if isinstance(w, (Input, Const)):
-                raise PyrtlInternalError('error, Inputs, Consts cannot be destinations to a net')
-        for w in net.args:
-            if isinstance(w, Output):
-                raise PyrtlInternalError('error, Outputs cannot be arguments for a net')
+        bad_dests = set(filter(lambda w: isinstance(w, (Input, Const)), net.dests))
+        if bad_dests:
+            raise PyrtlInternalError('error, Inputs, Consts cannot be destinations to a net (%s)' %
+                                     ','.join(map(str, bad_dests)))
+        bad_args = set(filter(lambda w: isinstance(w, (Output)), net.args))
+        if bad_args:
+            raise PyrtlInternalError('error, Outputs cannot be arguments for a net (%s)' %
+                                     ','.join(map(str, bad_args)))
 
         if net.op not in self.legal_ops:
             raise PyrtlInternalError('error, net op "%s" not from acceptable set %s' %


### PR DESCRIPTION
When importing BLIFs into PyRTL, I've had several experiences where the BLIF cannot be imported properly because some of the wires declared as outputs are also used as arguments to nets throughout the BLIF netlist. The proposed changes add information about exactly which wires are being misused this way in the reported error, making fixing the aforementioned problem (and hopefully the normal in-PyRTL development workflow) a little easier.

Example of what it looks like now (last line with 'ready_o'):
<img width="1062" alt="Screen Shot 2020-06-12 at 1 28 03 AM" src="https://user-images.githubusercontent.com/2482771/84482111-03d4ef80-ac4c-11ea-9b68-d5ce72055bbd.png">
