### PR TITLE
Decomposes graphviz default namer to accept a custom edge namer function and custom node namer function

### DIFF
--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -559,7 +559,7 @@ def detailed_edge_namer(extra_edge_info=None):
             name = ''
         else:
             name = '/'.join([edge.name, str(len(edge))])
-            if extra_edge_info:
+            if extra_edge_info and edge in extra_edge_info:
                 name = name + " (" +  str(extra_edge_info[edge]) + ")"
 
         penwidth = 2 if len(edge) == 1 else 6

--- a/tests/test_inputoutput.py
+++ b/tests/test_inputoutput.py
@@ -5,6 +5,7 @@ import pyrtl
 import six
 from pyrtl import inputoutput
 from pyrtl import verilog
+from pyrtl import analysis
 
 
 full_adder_blif = """\
@@ -321,6 +322,17 @@ class TestOutputGraphs(unittest.TestCase):
         with io.StringIO() as vfile:
             pyrtl.input_from_blif(full_adder_blif)
             pyrtl.output_to_graphviz(vfile)
+
+    def test_output_to_graphviz_with_custom_edge_namer_does_not_throw_error(self):
+        with io.StringIO() as vfile:
+            pyrtl.input_from_blif(full_adder_blif)
+            timing = analysis.TimingAnalysis()
+
+            def graph_namer(t, i, j):
+                edge_namer = pyrtl.inputoutput.detailed_edge_namer(timing.timing_map)
+                return pyrtl.inputoutput.graphviz_default_namer(t, i, j, edge_namer=edge_namer)
+
+            pyrtl.output_to_graphviz(vfile, namer=graph_namer)
 
 
 class TestOutputTestbench(unittest.TestCase):


### PR DESCRIPTION
As I was trying to correlate the textual timing information produced by `TimingAnalysis().timing_map` with the visual graph of the circuit produced by `output_to_graphviz()`, I thought it would helpful if a user could specify an edge-namer function when creating the the namer function that `output_to_graphviz()` accepts. This change decomposes the `graphviz_default_namer` function to accept both a `node_namer` function and an `edge_namer` function (using the defaults that were present already).

For example, now I can do this:

```python
timing = analysis.TimingAnalysis()

def graph_namer(t, i, j):
    edge_namer = pyrtl.inputoutput.detailed_edge_namer(timing.timing_map)
    return pyrtl.inputoutput.graphviz_default_namer(t, i, j, edge_namer=edge_namer)

with open(f"{name}.dot", "w+") as f:
    pyrtl.inputoutput.output_to_graphviz(f, namer=graph_namer)
```

The new function `pyrtl.inputoutput.detailed_edge_namer()` accepts as input a dict mapping edges to some arbitrary string, and will add this information to the matching edge. It also prints this for edges with names are prefixed with `tmp`.

Thus the above will turns what was previously this:

![nosplit](https://user-images.githubusercontent.com/2482771/85043004-bcb19780-b140-11ea-9d78-ec442396d50c.png)

into now this:

![nosplit-detailed](https://user-images.githubusercontent.com/2482771/85044340-52015b80-b142-11ea-997b-a6e0839cacdb.png)


The information in the parentheses can be arbitrary.