### PR TITLE
Adding a Bundle class for naming parts of wires

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -18,6 +18,7 @@ from .wire import WireVector
 from .wire import Input, Output
 from .wire import Const
 from .wire import Register
+from .wire import Bundle
 
 # helper functions
 

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -8,6 +8,7 @@ Types defined in this file include:
 * `Output` -- a wire vector that defines an output for a block
 * `Const` -- a wire vector fed by a constant
 * `Register` -- a wire vector that is latched each cycle
+* `Bundle` -- a wire vector that has named fields for easy access
 """
 
 from __future__ import print_function, unicode_literals
@@ -15,6 +16,8 @@ from __future__ import print_function, unicode_literals
 import numbers
 import six
 import re
+import sys
+from functools import reduce
 
 from . import core  # needed for _setting_keep_wirevector_call_stack
 
@@ -502,6 +505,19 @@ class WireVector(object):
             working_block().add_net(net)
             return concat(extvector, self)
 
+    def as_bundle(self, obj):
+        bundle_bw = Bundle.get_bundle_bitwidth(obj)
+
+        if len(self) != bundle_bw:
+            raise PyrtlError(
+                "Width of wire %s (%d) does not equal width of bundle %s (%d)"
+                % (str(self.name), len(self), str(obj.name), bundle_bw)
+            )
+
+        w = Bundle(obj)
+        w <<= self
+        return w
+
 
 # -----------------------------------------------------------------------
 #  ___     ___  ___       __   ___  __           ___  __  ___  __   __   __
@@ -701,3 +717,137 @@ class Register(WireVector):
         self.reg_in = next
         net = LogicNet('r', None, args=(self.reg_in,), dests=(self,))
         working_block().add_net(net)
+
+
+class Bundle(WireVector):
+    """ A WireVector whose individual bits are named.
+
+    The initializer takes as its first argument the name of a class whose
+    attributes will be interpreted as the names and lengths of fields in a wire.
+    The order in which the attributes are defined is important; the first class
+    attribute is the MSB of the wire, and the last class attribute of the list is the LSB.
+
+    For example, say there is a wire that represents an instruction. If we wanted to name
+    certain segments of bits a certain way, we would create a class with the names and lengths
+    of these fields as attributes follows:
+
+        class RFormat:
+            funct7 = 7
+            rs2 = 5
+            rs1 = 5
+            funct3 = 3
+            rd = 5
+            opcode = 7
+
+    Then use it as the argument to Bundle to get back an object whose fields are actually
+    wirevectors, accessible by field name:
+
+        w = pyrtl.Bundle(RFormat)
+        w <<= 0b00000100110001010000010110010011
+        assert sim.inspect(w.funct7) == 0b0000010
+        assert sim.inspect(w.rs2) == 0b01100
+        assert sim.inspect(w.rs1) == 0b01010
+        assert sim.inspect(w.funct3) == 0b000
+        assert sim.inspect(w.rd) == 0b01011
+        assert sim.inspect(w.opcode) == 0b0010011
+
+    It can be used anywhere a normal wire can be used:
+
+        r = pyrtl.Register(len(w), "r")
+        r.next <<= w
+        # ...after stepping a few times...
+        assert sim.inspect(r) == 0b00000100110001010000010110010011
+
+    And you can interpret other wires as instances of the bundled class, by calling
+    `as_bundle`. This does lightweight checks such as making sure that the bundled class
+    and the wire you call `as_bundle` on has the same length so that the bits can map properly.
+    This allows you to access portions of the wire via fields.
+
+        f7 = r.as_bundle(RFormat).funct7
+        assert sim.inspect(f7) == 0b0000010
+
+        y = r.as_bundle(RFormat)
+        assert sim.inspect(y.funct7) == 0b0000010
+        assert sim.inspect(y.rs2) == 0b01100
+        assert sim.inspect(y.rs1) == 0b01010
+        assert sim.inspect(y.funct3) == 0b000
+        assert sim.inspect(y.rd) == 0b01011
+        assert sim.inspect(y.opcode) == 0b0010011
+
+    You can also pass in a list of (field, width) pairs:
+
+        rformat = [("funct7", 7), ("rs2", 5), ("rs1", 5), ("funct3", 3), ("rd", 5), ("opcode", 7)]
+        w = pyrtl.Bundle(rformat)
+
+    or an (ordered) dictionary (OrderedDict is the default for Python >= 3.7):
+
+        rformat = {"funct7": 7, "rs2": 5, "rs1": 5, "funct3": 3, "rd": 5, "opcode": 7}
+        w = pyrtl.Bundle(rformat)
+
+    instead of a class to form a Bundle. In all forms, order is important.
+
+    In all cases, the 'width' member may actually be a tuple of the form (n, w),
+    where n is the actual width and f is a wirevector or function returning
+    a wirevector that will be used to define the wire. Otherwise, 'width' should
+    just be an integer and will be interpreted as the literal width.
+    """
+    @staticmethod
+    def _get_fields(obj):
+        if isinstance(obj, list) and all(map(lambda t: isinstance(t, tuple), obj)):
+            # Passed in a list of tuples (i.e. (field, width) pairs), in order from MSB to LSB
+            fields = obj
+        elif isinstance(obj, dict):
+            from collections import OrderedDict
+            if (not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7) and
+               (not isinstance(obj, OrderedDict))):
+                raise PyrtlError("For Python versions < 3.7, the dictionary used to instantiate "
+                                 "a Bundle must be explicitly ordered (i.e. OrderedDict)")
+            # Assume dictionary stores (field, width) pairs
+            fields = list(obj.items())
+        elif isinstance(obj, type):
+            if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7):
+                raise PyrtlError("Passing a class as an argument to Bundle() "
+                                 "is only allowed for Python versions >= 3.7")
+            # Let's assume 'obj' is a **class** name, so treat it as if it has field names.
+            # As of Python 3.7, dictionaries preserve insertion order, so a class's attributes
+            # (in __dict__) will being ordered as well. This relies on that fact because the
+            # fields are defined in MSB to LSB order in the class.
+            fs = filter(lambda attr: not attr.startswith("__"), vars(obj))
+            fields = [(attr, getattr(obj, attr)) for attr in fs]
+        else:
+            raise PyrtlError("Cannot determine (field, width) pairs from %s object" % type(obj))
+        return fields
+
+    @staticmethod
+    def get_bundle_bitwidth(obj):
+        fields = Bundle._get_fields(obj)
+        def aux(acc, t):
+            if isinstance(t[1], tuple):
+                width = t[1][0]
+            else:
+                width = t[1]
+            return acc + width
+        return reduce(aux, fields, 0)
+
+    def __init__(self, obj, name="", block=None):
+        super(Bundle, self).__init__(Bundle.get_bundle_bitwidth(obj), name, block)
+
+        fields = Bundle._get_fields(obj)
+        start = 0
+        args = []
+        for field, length in fields[::-1]:
+            if isinstance(length, tuple):
+                from .corecircuits import as_wires
+                # length is actually a tuple of the form (width, val)
+                val = length[1]
+                length = length[0]
+                if callable(val):
+                    val = val()
+                val = as_wires(val, bitwidth=length)
+                args.append(val)
+            setattr(self, field, self[start:start+length])
+            start += length
+        
+        if args:
+            from .corecircuits import concat_list
+            self <<= concat_list(args)

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -169,6 +169,76 @@ class TestWirevectorSlicing(unittest.TestCase):
         self.invalid_empty_slice(8, slice(-1, 1, 2))
 
 
+class TestWireAsBundle(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+
+    def test_create_bundle_from_tuples(self):
+        rformat = [
+            ("funct7", 7),
+            ("rs2", 5),
+            ("rs1", 5),
+            ("funct3", 3),
+            ("rd", 5),
+            ("opcode", 7),
+        ]
+        self.create_and_test_bundle(rformat)
+
+    def test_create_bundle_from_dict(self):
+        rformat = {
+            "funct7": 7,
+            "rs2": 5,
+            "rs1": 5,
+            "funct3": 3,
+            "rd": 5,
+            "opcode": 7
+        }
+        self.create_and_test_bundle(rformat)
+
+    def test_create_bundle_from_class(self):
+        class RFormat:
+            funct7 = 7
+            rs2 = 5
+            rs1 = 5
+            funct3 = 3
+            rd = 5
+            opcode = 7
+        self.create_and_test_bundle(RFormat)
+
+    def create_and_test_bundle(self, bundler):
+        w = pyrtl.Bundle(bundler)
+        assert isinstance(w, pyrtl.WireVector)
+        assert hasattr(w, 'funct7')
+        assert hasattr(w, 'rs2')
+        assert hasattr(w, 'rs1')
+        assert hasattr(w, 'funct3')
+        assert hasattr(w, 'rd')
+        assert hasattr(w, 'opcode')
+        assert len(w) == 32
+        assert len(w.funct7) == 7
+        assert len(w.rs2) == 5
+        assert len(w.rs1) == 5
+        assert len(w.funct3) == 3
+        assert len(w.rd) == 5
+        assert len(w.opcode) == 7
+
+        r = pyrtl.Register(len(w))
+        r.next <<= w
+        y = r.as_bundle(bundler)
+        assert hasattr(y, 'funct7')
+        assert hasattr(y, 'rs2')
+        assert hasattr(y, 'rs1')
+        assert hasattr(y, 'funct3')
+        assert hasattr(y, 'rd')
+        assert hasattr(y, 'opcode')
+        assert len(y) == 32
+        assert len(y.funct7) == 7
+        assert len(y.rs2) == 5
+        assert len(y.rs1) == 5
+        assert len(y.funct3) == 3
+        assert len(y.rd) == 5
+        assert len(y.opcode) == 7
+
 class TestInput(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()
@@ -355,3 +425,6 @@ class TestKeepingCallStack(unittest.TestCase):
         wire = pyrtl.WireVector()
         call_stack = wire.init_call_stack
         self.assertIsInstance(call_stack, list)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This creates a Bundle class, which is a subclass of WireVector. The main purpose is to provide handy read access of particular parts of a wire by giving these parts field names.

## Creation
Create a Bundle object by supplying either
* A list of (field name, width) tuples
```python
rformat = [("funct7", 7), ("rs2", 5), ("rs1", 5), ("funct3", 3), ("rd", 5), ("opcode", 7)]
w = pyrtl.Bundle(rformat)
```
* A dictionary mapping field names to widths
```python
rformat = {"funct7": 7, "rs2": 5, "rs1": 5, "funct3": 3, "rd": 5, "opcode": 7}
w = pyrtl.Bundle(rformat)
```
* A class whose sole attributes are widths of fields to be used
```python
class RFormat:
    funct7 = 7
    rs2 = 5
    rs1 = 5
    funct3 = 3
    rd = 5
    opcode = 7
w = pyrtl.Bundle(RFormat)
```

## Reading
In any of the above cases, the following should work:
```python
w <<= 0b00000100110001010000010110010011
sim = pyrtl.Simulation()
sim.step({})
assert sim.inspect(w.funct7) == 0b0000010
assert sim.inspect(w.rs2) == 0b01100
assert sim.inspect(w.rs1) == 0b01010
assert sim.inspect(w.funct3) == 0b000
assert sim.inspect(w.rd) == 0b01011
assert sim.inspect(w.opcode) == 0b0010011
```

## Wrapping with `as_bundle`
You can also wrap any arbitrary existing wire as a Bundle with the `as_bundle` function, which will allow you to access parts of the wire using your given field names:
```python
w = pyrtl.WireVector(8, 'w')
x = w.as_bundle({'a': 2, 'b': 3, 'c': 3})
w <<= 0b10101110
sim = pyrtl.Simulation()
sim.step({})
assert sim.inspect(x.a) == 0b10
assert sim.inspect(x.b) == 0b101
assert sim.inspect(x.c) == 0b110
```

## Experimental Instantiation
A final experimental feature is the ability to specify how wires used to create the Bundle wire itself should be created. A contrived example:
```python
x = pyrtl.Input(1, 'x')

def t1():
    w = pyrtl.WireVector(8)
    with pyrtl.conditional_assignment:
        with x:
            w |= 0b00101100
        with pyrtl.otherwise:
            w |= 0b10010011
        return w

class Array:
    entry1 = (8, t1)
    entry2 = (8, 0b01000011)
        
w = pyrtl.Bundle(Array, 'w')

sim = pyrtl.Simulation()
sim.step({'x': 1})
assert sim.inspect(w.entry1) == 0b00101100
assert sim.inspect(w.entry2) == 0b01000011

sim.step({'x': 0})
assert sim.inspect(w.entry1) == 0b10010011
assert sim.inspect(w.entry2) == 0b01000011
```

The above is equivalent to
```python
class Array:
    entry1 = (8, t1)
    entry2 = (8, 0b01000011)
        
w = pyrtl.Bundle(Array, 'w')
w1 = pyrtl.concat(t1(), 0b01000011)
w <<= w
```
so it remains to be seen if something like this extra functionality is useful.

Either way, I think at least having the read-only view abilities demonstrated in the the first three sections is useful.