### PR TITLE
Fixing typos, pep8, pylint, and some 2.7 test compat issues

### DIFF
--- a/examples/example3-statemachine.py
+++ b/examples/example3-statemachine.py
@@ -66,9 +66,9 @@ refund <<= state == REFUND
 # wirevector is 0.  4) There is a way to specify something like an "else" instead of "elif" and
 # that is with an "otherwise" (as seen on the line above "state.next <<= REFUND").  This condition
 # will be true if none of the other conditions at the same level were also true (for this example
-# specifically, state.next will get REFUND when req_refund==0, token_in==1, and state is not in TOK1,
-# TOK2, TOK3, or DISPENSE.   Finally 5) not shown here, you can update multiple different registers,
-# wires, and memories all under the same set of conditionals.
+# specifically, state.next will get REFUND when req_refund==0, token_in==1, and state is not in
+# TOK1, TOK2, TOK3, or DISPENSE.  Finally 5) not shown here, you can update multiple different
+# registers, wires, and memories all under the same set of conditionals.
 
 # A more artificial example might make it even more clear how these rules interact:
 # with a:

--- a/examples/introduction-to-hardware.py
+++ b/examples/introduction-to-hardware.py
@@ -127,7 +127,7 @@ def attempt3_hardware_fibonacci(n, bitwidth):
 # which keeps track of the iteration that we are on (i.next <<= i + 1).  The function
 # now returns two values, a reference to the register "a" and a reference to a single
 # bit that tells us if we are done.  That bit is calculated by comparing "i" to the
-# to a wirevector "n" that is passed in to see if they are the same. 
+# to a wirevector "n" that is passed in to see if they are the same.
 
 
 # Finally, we need a way to indicate that we want a new Fibonacci number.

--- a/pyrtl/analysis/estimate.py
+++ b/pyrtl/analysis/estimate.py
@@ -254,7 +254,7 @@ class TimingAnalysis(object):
         return 1e6 * 1.0/clock_period_in_ps
 
     def max_length(self):
-        """Returns the max timing delay of the circuit.
+        """Returns the max timing delay of the circuit in ps.
 
         The result assumes that the circuit is implemented in a 130nm process, and that there is no
         setup or hold time associated with the circuit.  The resulting value is in picoseconds.  If
@@ -348,7 +348,7 @@ def yosys_area_delay(library, abc_cmd=None, block=None):
     http://www.vlsitechnology.org/html/vsc_description.html
 
     May raise `PyrtlError` if yosys is not configured correctly, and
-    `PyrtlInternalError` if the call to yosys was not able successfully
+    `PyrtlInternalError` if the call to yosys was not successful
     """
 
     if abc_cmd is None:

--- a/pyrtl/conditional.py
+++ b/pyrtl/conditional.py
@@ -122,7 +122,7 @@ def _push_condition(predicate):
     _check_under_condition()
     _depth += 1
     if predicate is not otherwise and len(predicate) > 1:
-        raise PyrtlError('all predicates for conditional assignments must wirevectors of len 1')
+        raise PyrtlError('all predicates for conditional assignments must be wirevectors of len 1')
     _conditions_list_stack[-1].append(predicate)
     _conditions_list_stack.append([])
 

--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -12,6 +12,7 @@ from __future__ import print_function, unicode_literals
 import collections
 import re
 import keyword
+
 # from .helperfuncs import _currently_in_ipython
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 
@@ -63,7 +64,7 @@ class LogicNet(collections.namedtuple('LogicNet', ['op', 'op_param', 'args', 'de
                                            x must be one bit; len(a1) = len(a2)
         ('c', None, (*args), (out)) => concatenates *args (wires) into single WireVector;
                                        puts first arg at MSB, last arg at LSB
-        ('s', (sel), (wire), (out)) => selects bits frm wire based on sel (std slicing syntax),
+        ('s', (sel), (wire), (out)) => selects bits from wire based on sel (std slicing syntax),
                                        puts into out
         ('r', None, (next), (r1)) => on positive clock edge: copies next to r1
         ('m', (memid, mem), (addr), (data)) => read address addr of mem (w/ id memid),
@@ -466,7 +467,7 @@ class Block(object):
     def __iter__(self):
         """ BlockIterator iterates over the block passed on init in topographic order.
         The input is a Block, and when a LogicNet is returned it is always the case
-        that all of it's "parents" have already been returned earlier in the iteration.
+        that all of its "parents" have already been returned earlier in the iteration.
 
         Note: this method will throw an error if there are loops in the
         logic that do not involve registers
@@ -523,8 +524,8 @@ class Block(object):
             for w in wirevector_names_set:
                 wirevector_names_list.remove(w)
             raise PyrtlError('Duplicate wire names found for the following '
-                             'different signals: %s (make sure you are not using "tmp"'
-                             'or "const_" as a signal name because those are reserved for'
+                             'different signals: %s (make sure you are not using "tmp" '
+                             'or "const_" as a signal name because those are reserved for '
                              'internal use)' % repr(wirevector_names_list))
 
         # check for dead input wires (not connected to anything)
@@ -749,8 +750,10 @@ debug_mode = False
 _setting_keep_wirevector_call_stack = False
 _setting_slower_but_more_descriptive_tmps = False
 
+
 def _get_debug_mode():
     return debug_mode
+
 
 def _get_useful_callpoint_name():
     """ Attempts to find the lowest user-level call into the pyrtl module

--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -86,14 +86,14 @@ def select(sel, truecase, falsecase):
     """ Multiplexer returning falsecase for select==0, otherwise truecase.
 
     :param WireVector sel: used as the select input to the multiplexer
-    :param WireVector falsecase: the WireVector selected if select==0
     :param WireVector truecase: the WireVector selected if select==1
+    :param WireVector falsecase: the WireVector selected if select==0
 
     The hardware this generates is exactly the same as "mux" but by putting the
     true case as the first argument it matches more of the C-style ternary operator
     semantics which can be helpful for readablity.
 
-    Example of mux as "ternary operator" to take the max of 'a' and 5: ::
+    Example of mux as "ternary operator" to take the min of 'a' and 5: ::
 
         select( a<5, truecase=a, falsecase=5 )
     """
@@ -115,7 +115,7 @@ def concat(*args):
     You can provide multiple arguments and they will be combined with the right-most
     argument being the least significant bits of the result.  Note that if you have
     a list of arguments to concat together you will likely want index 0 to be the least
-    significant bit and so if you unpack the list into the arguements here it will be
+    significant bit and so if you unpack the list into the arguments here it will be
     backwards.  The function concat_list is provided for that case specifically.
 
     Example using concat to combine two bytes into a 16-bit quantity: ::
@@ -339,7 +339,7 @@ def match_bitwidth(*args, **opt):
 
 
 def as_wires(val, bitwidth=None, truncating=True, block=None):
-    """ Return wires from val which may be wires, integers, strings, or bools.
+    """ Return wires from val which may be wires, integers (including IntEnums), strings, or bools.
 
     :param val: a wirevector-like object or something that can be converted into
       a Const
@@ -457,13 +457,15 @@ def enum_mux(cntrl, table, default=None, strict=True):
     :return: a wirevector which is the result of the mux.
     ::
 
-        class Command(Enum):
+        from enum import IntEnum
+
+        class Command(IntEnum):
             ADD = 1
             SUB = 2
-        enum_mux(cntrl, {ADD: a+b, SUB: a-b})
-        enum_mux(cntrl, {ADD: a+b}, strict=False)  # SUB case undefined
-        enum_mux(cntrl, {ADD: a+b, otherwise: a-b})
-        enum_mux(cntrl, {ADD: a+b}, default=a-b)
+        enum_mux(cntrl, {Command.ADD: a+b, Command.SUB: a-b})
+        enum_mux(cntrl, {Command.ADD: a+b}, strict=False)  # SUB case undefined
+        enum_mux(cntrl, {Command.ADD: a+b, otherwise: a-b})
+        enum_mux(cntrl, {Command.ADD: a+b}, default=a-b)
 
     """
     # check dictionary keys are of the right type

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -137,7 +137,7 @@ def log2(integer_val):
 def truncate(wirevector_or_integer, bitwidth):
     """ Returns a wirevector or integer truncated to the specified bitwidth
 
-    :param wirevector_or_integer: Either a wirevector or and integer to be truncated
+    :param wirevector_or_integer: Either a wirevector or an integer to be truncated
     :param bitwidth: The length to which the first argument should be truncated.
     :return: Returns a tuncated wirevector or integer as appropriate
 
@@ -148,8 +148,8 @@ def truncate(wirevector_or_integer, bitwidth):
 
     Examples: ::
 
-        truncate(9,3)  # returns 3  (0b101 truncates to 0b101)
-        truncate(5,3)  # returns 3  (0b1001 truncates to 0b001)
+        truncate(9,3)  # returns 1  (0b1001 truncates to 0b001)
+        truncate(5,3)  # returns 5  (0b101 truncates to 0b101)
         truncate(-1,3)  # returns 7  (-0b1 truncates to 0b111)
         y = truncate(x+1, x.bitwidth)  # y.bitwdith will equal x.bitwidth
     """
@@ -171,7 +171,7 @@ def chop(w, *segment_widths):
 
     This function chops a wirevector into a set of smaller wirevectors of different
     lengths.  It is most useful when multiple "fields" are contained with a single
-    wirevector, for example when breaking apart and instruction.  For example, if
+    wirevector, for example when breaking apart an instruction.  For example, if
     you wish to break apart a 32-bit MIPS I-type (Immediate) instruction you know
     it has an 6-bit opcode, 2 5-bit operands, and 16-bit offset.  You could take
     each of those slices in absolute terms: offset=instr[0:16], rt=instr[16:21]

--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -149,6 +149,7 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk'):
                 raise PyrtlError('unknown command type')
 
     def extract_cover(command):
+        # pylint: disable=invalid-unary-operand-type
         netio = command['namesignal_list']
         if len(command['cover_list']) == 0:
             output_wire = twire(netio[0])
@@ -205,9 +206,10 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk'):
         if init_val == "1":
             # e.g. in Verilog: `initial reg <= 1;`
             raise PyrtlError("Initializing latches to 1 is not supported. "
-                              "Acceptable values are: 0, 2 (don't care), and 3 (unknown); in any case, "
-                              "PyRTL will ensure all stateful elements come up 0. "
-                              "For finer control over the initial value, use specialized reset logic.")
+                             "Acceptable values are: 0, 2 (don't care), and 3 (unknown); "
+                             "in any case, PyRTL will ensure all stateful elements come up 0. "
+                             "For finer control over the initial value, use specialized reset "
+                             "logic.")
         flop_output <<= flop
 
     for model in result:
@@ -544,6 +546,7 @@ def graphviz_default_namer(
     else:
         return node_namer(thing)
 
+
 def detailed_edge_namer(extra_edge_info=None):
     """
     A function for naming an edge for use in the graphviz graph.
@@ -560,7 +563,7 @@ def detailed_edge_namer(extra_edge_info=None):
         else:
             name = '/'.join([edge.name, str(len(edge))])
             if extra_edge_info and edge in extra_edge_info:
-                name = name + " (" +  str(extra_edge_info[edge]) + ")"
+                name = name + " (" + str(extra_edge_info[edge]) + ")"
 
         penwidth = 2 if len(edge) == 1 else 6
         arrowhead = 'none' if is_to_splitmerge else 'normal'

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -151,7 +151,7 @@ class MemBlock(_MemReadBase):
 
         data <<= memory[addr]  (infer read port)
         memory[addr] <<= data  (infer write port)
-        mem[address] = MemBlock.EnabledWrite(data,enable=we)
+        mem[address] <<= MemBlock.EnabledWrite(data,enable=we)
 
     When the address of a memory is assigned to using a EnableWrite object
     items will only be written to the memory when the enable WireVector is
@@ -289,7 +289,7 @@ class RomBlock(_MemReadBase):
             simulation should throw an error on access of unintialized data.  If you are generating
             verilog from the rom, you will need to specify a value for every address (in which case
             setting this to True will help), however for testing and simulation it useful to know if
-            you are off the end of explicitly specified values (which is wy it is False by default)
+            you are off the end of explicitly specified values (which is why it is False by default)
         :param block: The block to add to, defaults to the working block
         """
 
@@ -303,7 +303,7 @@ class RomBlock(_MemReadBase):
     def __getitem__(self, item):
         import numbers
         if isinstance(item, numbers.Number):
-            raise PyrtlError("There is no point in indexing into a RomBlock with an int "
+            raise PyrtlError("There is no point in indexing into a RomBlock with an int. "
                              "Instead, get the value from the source data for this Rom")
             # If you really know what you are doing, use a Const WireVector instead.
         return super(RomBlock, self).__getitem__(item)

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -15,7 +15,7 @@ from .memory import MemBlock
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .wire import WireVector, Input, Output, Const, Register
 from .transform import net_transform, _get_new_block_mem_instance, copy_block, replace_wires
-from . import transform  # transform.all_nets loos better than all_nets
+from . import transform  # transform.all_nets looks better than all_nets
 
 
 # --------------------------------------------------------------------

--- a/pyrtl/rtllib/muxes.py
+++ b/pyrtl/rtllib/muxes.py
@@ -26,7 +26,7 @@ def prioritized_mux(selects, vals):
                             falsecase=prioritized_mux(selects[half:], vals[half:]))
 
 
-def _is_equivelent(w1, w2):
+def _is_equivalent(w1, w2):
     if isinstance(w1, pyrtl.Const) & isinstance(w2, pyrtl.Const):
         return (w1.val == w2.val) & (w1.bitwidth == w2.bitwidth)
     return w1 is w2
@@ -103,7 +103,7 @@ def _sparse_mux(sel, vals):
 
         false_result = sparse_mux(sel[:-1], first_dict)
         true_result = sparse_mux(sel[:-1], second_dict)
-    if _is_equivelent(false_result, true_result):
+    if _is_equivalent(false_result, true_result):
         return true_result
     return pyrtl.select(sel[-1], falsecase=false_result, truecase=true_result)
 

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -61,7 +61,7 @@ class Simulation(object):
             If the default (true) is passed, Simulation will create a new tracer automatically
             which can be referenced by the member variable .tracer
         :param register_value_map: Defines the initial value for
-          the roms specified. Format: {Register: value}.
+          the registers specified. Format: {Register: value}.
         :param memory_value_map: Defines initial values for many
           addresses in a single or multiple memory. Format: {Memory: {address: Value}}.
           Memory is a memory block, address is the address of a value
@@ -229,7 +229,7 @@ class Simulation(object):
             supplied input value)
         :param file: where to write the output (if there are unexpected outputs detected)
         :param stop_after_first_error: a boolean flag indicating whether to stop the simulation
-            after the step where the first errors are encountered (defaults to False)
+            after encountering the first error (defaults to False)
 
         All input wires must be in the provided_inputs in order for the simulation
         to accept these values. Additionally, the length of the array of provided values for each
@@ -263,8 +263,8 @@ class Simulation(object):
             sim = pyrtl.Simulation()
             sim.step_multiple({}, steps=3)
 
-        Using sim.step_multiple(3) simulates 3 cycles, after which we would expect the value of 'b'
-        to be 2.
+        Using sim.step_multiple({}, 3) simulates 3 cycles, after which we would expect the value
+        of 'b' to be 2.
 
         """
 
@@ -595,8 +595,8 @@ class FastSimulation(object):
             sim = pyrtl.Simulation()
             sim.step_multiple({}, steps=3)
 
-        Using sim.step_multiple(3) simulates 3 cycles, after which we would expect the value of 'b'
-        to be 2.
+        Using sim.step_multiple({}, 3) simulates 3 cycles, after which we would expect the value
+        of 'b' to be 2.
 
         """
 
@@ -1072,12 +1072,12 @@ class SimulationTrace(object):
         :param include_clock: boolean specifying if the implicit clk should be included.
 
         Dumps the current trace to file as a "value change dump" file.  The file parameter
-        defaults to _stdout_ and the include_clock defaults to True.
+        defaults to _stdout_ and the include_clock defaults to False.
 
         Examples ::
 
             sim_trace.print_vcd()
-            sim_trace.print_vcd("my_waveform.vcd", include_clock=False)
+            sim_trace.print_vcd("my_waveform.vcd", include_clock=True)
         """
         # dump header info
         # file_timestamp = time.strftime("%a, %d %b %Y %H:%M:%S (UTC/GMT)", time.gmtime())

--- a/pyrtl/transform.py
+++ b/pyrtl/transform.py
@@ -142,7 +142,7 @@ def replace_wire_fast(orig_wire, new_src, new_dst, src_nets, dst_nets, block=Non
     # src and dst in this function are all relative to wires
     block = working_block(block)
     if new_src is not orig_wire and orig_wire in src_nets:
-        # don't need to add the new_src and new_dst because they were made added at creation
+        # don't need to add the new_src and new_dst because they were made at creation
         net = src_nets[orig_wire]
         new_net = LogicNet(
             op=net.op, op_param=net.op_param, args=net.args,
@@ -168,7 +168,7 @@ def clone_wire(old_wire, name=None):
     Makes a copy of any existing wire
 
     :param old_wire: The wire to clone
-    :param name: a name fo rhte new wire
+    :param name: a name for the new wire
 
     Note that this function is mainly intended to be used when the
     two wires are from different blocks. Making two wires with the

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -652,7 +652,7 @@ class Register(WireVector):
 
         def __bool__(self):
             """ Use of a _next in a statement like "a or b" is forbidden."""
-            raise PyrtlError('cannot covert Register.next to compile-time boolean.  This error '
+            raise PyrtlError('cannot convert Register.next to compile-time boolean.  This error '
                              'often happens when you attempt to use a Register.next with "==" or '
                              'something that calls "__eq__", such as when you test if a '
                              'Register.next is "in" something')
@@ -804,7 +804,7 @@ class Bundle(WireVector):
                                  "a Bundle must be explicitly ordered (i.e. OrderedDict)")
             # Assume dictionary stores (field, width) pairs
             fields = list(obj.items())
-        elif isinstance(obj, type):
+        elif isinstance(obj, six.class_types):
             if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7):
                 raise PyrtlError("Passing a class as an argument to Bundle() "
                                  "is only allowed for Python versions >= 3.7")
@@ -821,6 +821,7 @@ class Bundle(WireVector):
     @staticmethod
     def get_bundle_bitwidth(obj):
         fields = Bundle._get_fields(obj)
+
         def aux(acc, t):
             if isinstance(t[1], tuple):
                 width = t[1][0]
@@ -847,7 +848,7 @@ class Bundle(WireVector):
                 args.append(val)
             setattr(self, field, self[start:start+length])
             start += length
-        
+
         if args:
             from .corecircuits import concat_list
             self <<= concat_list(args)

--- a/tests/rtllib/test_muxes.py
+++ b/tests/rtllib/test_muxes.py
@@ -70,26 +70,26 @@ class TestPrioritizedMuxSim(unittest.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestIsEquivelent(unittest.TestCase):
+class TestIsEquivalent(unittest.TestCase):
     def test_equivalent_const(self):
         a = pyrtl.Const(1)
         b = pyrtl.Const(1)
         c = pyrtl.Const(1, 2)
         d = pyrtl.Const(3)
-        self.assertTrue(muxes._is_equivelent(a, a))
-        self.assertTrue(muxes._is_equivelent(a, b))
-        self.assertFalse(muxes._is_equivelent(a, c))
-        self.assertFalse(muxes._is_equivelent(a, d))
+        self.assertTrue(muxes._is_equivalent(a, a))
+        self.assertTrue(muxes._is_equivalent(a, b))
+        self.assertFalse(muxes._is_equivalent(a, c))
+        self.assertFalse(muxes._is_equivalent(a, d))
 
     def test_equivalent(self):
         a = pyrtl.WireVector(2)
         b = pyrtl.Const(2, 2)
         c = pyrtl.Output()
 
-        self.assertTrue(muxes._is_equivelent(a, a))
-        self.assertTrue(muxes._is_equivelent(c, c))
-        self.assertFalse(muxes._is_equivelent(a, b))
-        self.assertFalse(muxes._is_equivelent(a, c))
+        self.assertTrue(muxes._is_equivalent(a, a))
+        self.assertTrue(muxes._is_equivalent(c, c))
+        self.assertFalse(muxes._is_equivalent(a, b))
+        self.assertFalse(muxes._is_equivalent(a, c))
 
 
 class TestSmartMuxTrivial(unittest.TestCase):

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -182,7 +182,7 @@ class TestWireAsBundle(unittest.TestCase):
             ("rd", 5),
             ("opcode", 7),
         ]
-        self.create_and_test_bundle(rformat)
+        self.create_and_check_bundle(rformat)
 
     def test_create_bundle_from_dict(self):
         rformat = {
@@ -193,7 +193,15 @@ class TestWireAsBundle(unittest.TestCase):
             "rd": 5,
             "opcode": 7
         }
-        self.create_and_test_bundle(rformat)
+        if six.PY2:
+            with self.assertRaises(pyrtl.PyrtlError) as ex:
+                self.create_and_check_bundle(rformat)
+            self.assertEqual(str(ex.exception),
+                "For Python versions < 3.7, the dictionary used to instantiate "
+                "a Bundle must be explicitly ordered (i.e. OrderedDict)"
+            )
+        else:
+            self.create_and_check_bundle(rformat)
 
     def test_create_bundle_from_class(self):
         class RFormat:
@@ -203,9 +211,17 @@ class TestWireAsBundle(unittest.TestCase):
             funct3 = 3
             rd = 5
             opcode = 7
-        self.create_and_test_bundle(RFormat)
+        if six.PY2:
+            with self.assertRaises(pyrtl.PyrtlError) as ex:
+                self.create_and_check_bundle(RFormat)
+            self.assertEqual(str(ex.exception),
+                "Passing a class as an argument to Bundle() is only "
+                "allowed for Python versions >= 3.7"
+            )
+        else:
+            self.create_and_check_bundle(RFormat)
 
-    def create_and_test_bundle(self, bundler):
+    def create_and_check_bundle(self, bundler):
         w = pyrtl.Bundle(bundler)
         assert isinstance(w, pyrtl.WireVector)
         assert hasattr(w, 'funct7')


### PR DESCRIPTION
Fixes various typos and more importantly some tox issues (pep8, pylint, and some 2.7 test compatibility issues by adding usage of `six` where appropriate). The 2.7 compatibility issues fixed here weren't syntactic (so the code in the current development branch still runs for 2.7), but the additional fixes here make the tests more robust to reflect when 2.7 is being run so the correct exception is caught, and uses `six.callable` rather than `type` in the Bundle `get_fields` method.