### PR TITLE
Fix block netlist and critical paths display when in Jupyter notebook vs Python/IPython

### DIFF
--- a/pyrtl/analysis/estimate.py
+++ b/pyrtl/analysis/estimate.py
@@ -18,6 +18,7 @@ from ..wire import Input, Const, Register
 from ..pyrtlexceptions import PyrtlError, PyrtlInternalError
 from ..verilog import output_to_verilog
 from ..memory import RomBlock
+from ..helperfuncs import _currently_in_jupyter_notebook, _print_netlist_latex
 
 
 # --------------------------------------------------------------------
@@ -321,8 +322,11 @@ class TimingAnalysis(object):
         for cp_with_num in enumerate(critical_paths):
             print("Critical path", cp_with_num[0], ":")
             print(line_indent, "The first wire is:", cp_with_num[1][0])
-            for net in cp_with_num[1][1]:
-                print(line_indent, (net))
+            if _currently_in_jupyter_notebook():
+                _print_netlist_latex(list(net for net in cp_with_num[1][1]))
+            else:
+                for net in cp_with_num[1][1]:
+                    print(line_indent, (net))
             print()
 
 

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -642,13 +642,34 @@ def print_loop(loop_data):
         print("")
 
 
-def _currently_in_ipython():
-    """ Return true if running under ipython, otherwise return False. """
+def _currently_in_jupyter_notebook():
+    """
+    Return true if running under Jupyter notebook, otherwise return False.
+
+    We want to check for more than just the presence of __IPYTHON__ because
+    that is present in both Jupyter notebooks and IPython terminals.
+    """
     try:
-        __IPYTHON__  # pylint: disable=undefined-variable
-        return True
+        # get_ipython() is in the global namespace when ipython is started
+        shell = get_ipython().__class__.__name__
+        if shell == 'ZMQInteractiveShell':
+            return True   # Jupyter notebook or qtconsole
+        elif shell == 'TerminalInteractiveShell':
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type
     except NameError:
-        return False
+        return False      # Probably standard Python interpreter
+
+
+def _print_netlist_latex(netlist):
+    """ Print each net in netlist in a Latex array """
+    from IPython.display import display, Latex  # pylint: disable=import-error
+    out = '\n\\begin{array}{ \| c \| c \| l \| }\n'
+    out += '\n\hline\n'
+    out += '\\hline\n'.join(str(n) for n in netlist)
+    out += '\hline\n\\end{array}\n'
+    display(Latex(out))
 
 
 class _NetCount(object):

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -11,7 +11,7 @@ from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import working_block, PostSynthBlock, _PythonSanitizer
 from .wire import Input, Register, Const, Output, WireVector
 from .memory import RomBlock
-from .helperfuncs import check_rtl_assertions, _currently_in_ipython
+from .helperfuncs import check_rtl_assertions, _currently_in_jupyter_notebook
 from .verilog import _VerilogSanitizer
 
 # ----------------------------------------------------------------
@@ -1141,7 +1141,7 @@ class SimulationTrace(object):
         at with "more" or "less -R" which both should handle the ASCII escape
         sequences used in rendering.
         """
-        if _currently_in_ipython():
+        if _currently_in_jupyter_notebook():
             from IPython.display import display, HTML, Javascript  # pylint: disable=import-error
             from .inputoutput import trace_to_html
             htmlstring = trace_to_html(self, trace_list=trace_list, sortkey=_trace_sort_key)


### PR DESCRIPTION
# Summary
While working on retiming, it's been useful to view the netlist and critical paths. I noticed that it was always printing the edges using Latex notation, even when I wasn't in a Jupyter notebook. The changes are:
* Changes `_currently_in_ipython` to `_currently_in_jupyter_notebook`, replacing the check for `__IPYTHON__` with a more specific check to see if the current terminal is the one used by Jupyter (since `__IPYTHON__` is true when running `ipython` at the terminal and in Jupyter, and we only really care if we're in Jupyter for displaying that Latex notation)
* Uses `_currently_in_jupyter_notebook` throughout PyRTL for consistency, replacing the ad-hoc checks for ipython importability (which wouldn't fail even when in a regular terminal)
* Creates a function `_print_netlist_latex` that is used within `Block` and `TimingAnalysis` for consistency
* (Minor) changes the "\~" symbol used when displaying inversion to "\sim", since "\~" leaves a literal backslash and tilde character rather than a tilde character

# Tests
* `tox` passes all tests.

* Also, some pictures of before and after.

## Python/IPython
Before (printing block in python or ipython):
<img width="819" alt="before_print-block-in-terminal" src="https://user-images.githubusercontent.com/2482771/95377194-14fad980-0897-11eb-9636-8d62df7339b6.png">

After (printing block in python or ipython) (notice removal of Latex commands):
<img width="1130" alt="after_print-block-in-terminal" src="https://user-images.githubusercontent.com/2482771/95377222-204e0500-0897-11eb-8492-5e49554c28c2.png">

Before (printing critical paths in python or ipython):
<img width="561" alt="before_print-critical-paths-in-terminal" src="https://user-images.githubusercontent.com/2482771/95377335-45db0e80-0897-11eb-811f-4573cbe7850c.png">

After (printing critical paths in python or ipython):
<img width="1130" alt="after_print-critical-paths-in-terminal" src="https://user-images.githubusercontent.com/2482771/95377362-5095a380-0897-11eb-86e8-70aefeda4dd2.png">

## Jupyter notebook

Before (printing block in Jupyter notebook):
<img width="1130" alt="before_print-block-in-ipython" src="https://user-images.githubusercontent.com/2482771/95377401-5be8cf00-0897-11eb-8d21-62964722af16.png">

After (printing block in Jupyter notebook):
<img width="1130" alt="after_print-block-in-ipython" src="https://user-images.githubusercontent.com/2482771/95377432-699e5480-0897-11eb-8134-e7448937fca2.png">

Before (printing critical paths in Jupyter notebook):
<img width="1130" alt="before_print-critical-paths-in-ipython" src="https://user-images.githubusercontent.com/2482771/95377519-85a1f600-0897-11eb-90ce-c6d9ba1bb5aa.png">

After (printing critical paths in Jupyter notebook):
<img width="1130" alt="after_print-critical-paths-in-ipython" src="https://user-images.githubusercontent.com/2482771/95377456-74f18000-0897-11eb-862e-354742bb8063.png">