### PR TITLE
Various updates to inputoutput functions

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -85,6 +85,7 @@ from .compilesim import CompiledSimulation
 from .inputoutput import input_from_blif
 from .inputoutput import output_to_trivialgraph
 from .inputoutput import output_to_graphviz
+from .inputoutput import output_to_svg
 from .inputoutput import output_to_firrtl
 from .inputoutput import block_to_graphviz_string
 from .inputoutput import block_to_svg

--- a/tests/test_inputoutput.py
+++ b/tests/test_inputoutput.py
@@ -366,15 +366,15 @@ class TestOutputGraphs(unittest.TestCase):
             pyrtl.input_from_blif(full_adder_blif)
             pyrtl.output_to_graphviz(vfile)
 
-    def test_output_to_graphviz_with_custom_edge_namer_does_not_throw_error(self):
+    def test_output_to_graphviz_with_custom_namer_does_not_throw_error(self):
         with io.StringIO() as vfile:
             pyrtl.input_from_blif(full_adder_blif)
             timing = analysis.TimingAnalysis()
-
-            def graph_namer(t, i, j):
-                edge_namer = pyrtl.inputoutput.detailed_edge_namer(timing.timing_map)
-                return pyrtl.inputoutput.graphviz_default_namer(t, i, j, edge_namer=edge_namer)
-
+            node_fan_in = {net: len(net.args) for net in pyrtl.working_block()}
+            graph_namer = pyrtl.inputoutput.graphviz_detailed_namer(
+                extra_node_info=node_fan_in,
+                extra_edge_info=timing.timing_map
+            )
             pyrtl.output_to_graphviz(vfile, namer=graph_namer)
 
 


### PR DESCRIPTION
This PR does a few things:

1. It cleans up the graphviz detailed namers, making it easier to use by 1) augmenting the existing default namers with my previous detailed namer changes and more importantly 2) exposing a `detailed_graphviz_namer`, which takes in `extra_edge_info` and `extra_node_info` maps. I feel that it's now easier to add custom information next to each node and edge.

2. It adds an option to the graphviz namers to not split the state. This merely exposes the `split_state` argument that was previously always hard-coded in the `net_graph` calls from `block_to_graphviz_string`/`output_to_trivialgraph`.

So now, whereas before the graphviz would always look like:

![correlator](https://user-images.githubusercontent.com/2482771/103711843-27a3ae00-4f6d-11eb-9524-d71fe11e91ae.png)

It can now look like this when `split_state=False` is passed to `output_to_graphviz`:

![correlator](https://user-images.githubusercontent.com/2482771/103711802-10fd5700-4f6d-11eb-8ab5-ec67022c91ca.png)

3. It adds an `output_to_svg` helper (to match the `output_to_graphviz` function); this isn't major, but I don't see any downside.

4. It adds documentation.