### PR TITLE
Correct and git ignore htmlcov coverage output folder; don't report on .tox contents

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -28,3 +28,4 @@ exclude_lines =
 
 ignore_errors = True
 
+omit = .tox/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.py[cod]
 
 # coverage
-htmlconv/
+htmlcov/
 .coverage/
 
 # C extensions


### PR DESCRIPTION
This is a quick fix to the coverage-related framework. The html coverage information is put in `htmlcov`, not `htmlconv`, and we need to ignore `.tox/` contents when reporting.

Before:
<img width="1001" alt="Screen Shot 2021-01-05 at 4 48 15 PM" src="https://user-images.githubusercontent.com/2482771/103715567-d0eea200-4f75-11eb-94a0-348b4eb96efe.png">

After:

<img width="714" alt="Screen Shot 2021-01-05 at 4 45 57 PM" src="https://user-images.githubusercontent.com/2482771/103715444-7d7c5400-4f75-11eb-93c4-700d244d4ba6.png">
