### PR TITLE
Make error message for multiple drivers more helpful

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -418,7 +418,7 @@ class Block(object):
         well as facilitate other places in which one would need wire source
         and wire sink information
 
-        Look at input_output.net_graph for one such graph that uses the information
+        Look at inputoutput.net_graph for one such graph that uses the information
         from this function
         """
         src_list = {}
@@ -426,8 +426,10 @@ class Block(object):
 
         def add_wire_src(edge, node):
             if edge in src_list:
-                raise PyrtlError('Wire "{}" has multiple drivers (check for multiple assignments '
-                                 'with "<<=" or accidental mixing of "|=" and "<<=")'.format(edge))
+                raise PyrtlError('Wire "{}" has multiple drivers: [{}] and [{}] (check for '
+                                 'multiple assignments with "<<=" or accidental mixing of '
+                                 '"|=" and "<<=")'
+                                 .format(edge, str(src_list[edge]).strip(), str(node).strip()))
             src_list[edge] = node
 
         def add_wire_dst(edge, node):


### PR DESCRIPTION
As I've been writing netlist transformations, it's been helpful to have additional information when I (often) make the mistake of creating wires with multiple drivers. This change prints out the nets that are causing the problem. This is especially useful in conjunction with `pyrtl.set_debug_mode()` since the net argument wire names will include the line number of the one of the offending assignments.

Given this (in the code I'm writing, the problem isn't usually so obvious):
```
import pyrtl

pyrtl.set_debug_mode()
a = pyrtl.Output(2, 'a')
b, c = pyrtl.input_list('b/2 c/2')
a <<= b + 1
a <<= c + 1

sim = pyrtl.Simulation()
```

before it would just print:
```
pyrtl.pyrtlexceptions.PyrtlError: Wire "a/2O" has multiple drivers (check for multiple assignments with "<<=" or accidental mixing of "|=" and "<<=")
```

but now prints:
```
pyrtl.pyrtlexceptions.PyrtlError: Wire "a/2O" has multiple drivers: [a/2O <-- w -- tmp7_multipledrivers_line7/2W] and [a/2O <-- w -- tmp3_multipledrivers_line6/2W] (check for multiple assignments with "<<=" or accidental mixing of "|=" and "<<=")
```