### PR TITLE
Make step_multiple parameters more descriptive, remove need for inputs when appropriate

### DIFF
--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -120,7 +120,7 @@ class CompiledSimulation(object):
         """
         self.run([inputs])
 
-    def step_multiple(self, provided_inputs, expected_outputs=None, nsteps=None,
+    def step_multiple(self, provided_inputs={}, expected_outputs={}, nsteps=None,
                       file=sys.stdout, stop_after_first_error=False):
         """ Take the simulation forward N cycles, where N is the number of values
          for each provided input.
@@ -164,10 +164,10 @@ class CompiledSimulation(object):
             b <<= a
 
             sim = pyrtl.Simulation()
-            sim.step_multiple({}, steps=3)
+            sim.step_multiple(nsteps=3)
 
-        Using sim.step_multiple(3) simulates 3 cycles, after which we would expect the value of 'b'
-        to be 2.
+        Using sim.step_multiple(nsteps=3) simulates 3 cycles, after which we would expect the value
+        of 'b' to be 2.
 
         """
 
@@ -194,7 +194,7 @@ class CompiledSimulation(object):
                 "must supply a value for each provided wire "
                 "for each step of simulation")
 
-        if expected_outputs and list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
+        if list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
             raise PyrtlError(
                 "any expected outputs must have a supplied value "
                 "each step of simulation")
@@ -203,12 +203,11 @@ class CompiledSimulation(object):
         for i in range(nsteps):
             self.step({w: int(v[i]) for w, v in provided_inputs.items()})
 
-            if expected_outputs is not None:
-                for expvar in expected_outputs.keys():
-                    expected = int(expected_outputs[expvar][i])
-                    actual = self.inspect(expvar)
-                    if expected != actual:
-                        failed.append((i, expvar, expected, actual))
+            for expvar in expected_outputs.keys():
+                expected = int(expected_outputs[expvar][i])
+                actual = self.inspect(expvar)
+                if expected != actual:
+                    failed.append((i, expvar, expected, actual))
 
             if failed and stop_after_first_error:
                 break

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -217,7 +217,7 @@ class Simulation(object):
         # raise the appropriate exceptions
         check_rtl_assertions(self)
 
-    def step_multiple(self, provided_inputs, expected_outputs=None, nsteps=None,
+    def step_multiple(self, provided_inputs={}, expected_outputs={}, nsteps=None,
                       file=sys.stdout, stop_after_first_error=False):
         """ Take the simulation forward N cycles, where N is the number of values
          for each provided input.
@@ -261,9 +261,9 @@ class Simulation(object):
             b <<= a
 
             sim = pyrtl.Simulation()
-            sim.step_multiple({}, steps=3)
+            sim.step_multiple(nsteps=3)
 
-        Using sim.step_multiple({}, 3) simulates 3 cycles, after which we would expect the value
+        Using sim.step_multiple(nsteps=3) simulates 3 cycles, after which we would expect the value
         of 'b' to be 2.
 
         """
@@ -291,7 +291,7 @@ class Simulation(object):
                 "must supply a value for each provided wire "
                 "for each step of simulation")
 
-        if expected_outputs and list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
+        if list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
             raise PyrtlError(
                 "any expected outputs must have a supplied value "
                 "each step of simulation")
@@ -300,12 +300,11 @@ class Simulation(object):
         for i in range(nsteps):
             self.step({w: int(v[i]) for w, v in provided_inputs.items()})
 
-            if expected_outputs is not None:
-                for expvar in expected_outputs.keys():
-                    expected = int(expected_outputs[expvar][i])
-                    actual = self.inspect(expvar)
-                    if expected != actual:
-                        failed.append((i, expvar, expected, actual))
+            for expvar in expected_outputs.keys():
+                expected = int(expected_outputs[expvar][i])
+                actual = self.inspect(expvar)
+                if expected != actual:
+                    failed.append((i, expvar, expected, actual))
 
             if failed and stop_after_first_error:
                 break
@@ -549,7 +548,7 @@ class FastSimulation(object):
         # check the rtl assertions
         check_rtl_assertions(self)
 
-    def step_multiple(self, provided_inputs, expected_outputs=None, nsteps=None,
+    def step_multiple(self, provided_inputs={}, expected_outputs={}, nsteps=None,
                       file=sys.stdout, stop_after_first_error=False):
         """ Take the simulation forward N cycles, where N is the number of values
          for each provided input.
@@ -593,9 +592,9 @@ class FastSimulation(object):
             b <<= a
 
             sim = pyrtl.Simulation()
-            sim.step_multiple({}, steps=3)
+            sim.step_multiple(nsteps=3)
 
-        Using sim.step_multiple({}, 3) simulates 3 cycles, after which we would expect the value
+        Using sim.step_multiple(nsteps=3) simulates 3 cycles, after which we would expect the value
         of 'b' to be 2.
 
         """
@@ -623,7 +622,7 @@ class FastSimulation(object):
                 "must supply a value for each provided wire "
                 "for each step of simulation")
 
-        if expected_outputs and list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
+        if list(filter(lambda l: len(l) < nsteps, expected_outputs.values())):
             raise PyrtlError(
                 "any expected outputs must have a supplied value "
                 "each step of simulation")
@@ -632,12 +631,11 @@ class FastSimulation(object):
         for i in range(nsteps):
             self.step({w: int(v[i]) for w, v in provided_inputs.items()})
 
-            if expected_outputs is not None:
-                for expvar in expected_outputs.keys():
-                    expected = int(expected_outputs[expvar][i])
-                    actual = self.inspect(expvar)
-                    if expected != actual:
-                        failed.append((i, expvar, expected, actual))
+            for expvar in expected_outputs.keys():
+                expected = int(expected_outputs[expvar][i])
+                actual = self.inspect(expvar)
+                if expected != actual:
+                    failed.append((i, expvar, expected, actual))
 
             if failed and stop_after_first_error:
                 break

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -314,7 +314,7 @@ class SimStepMultipleBase(unittest.TestCase):
 
         sim_trace = pyrtl.SimulationTrace()
         sim = self.sim(tracer=sim_trace)
-        sim.step_multiple({}, nsteps=5)
+        sim.step_multiple(nsteps=5)
 
         correct_output = ("--- Values in base 10 ---\n"
                           "b 0 1 2 3 4\n")
@@ -337,7 +337,7 @@ class SimStepMultipleBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace)
 
         with self.assertRaises(pyrtl.PyrtlError) as error:
-            sim.step_multiple({})
+            sim.step_multiple()
         self.assertEqual(str(error.exception),
                          'need to supply either input values '
                          'or a number of steps to simulate')

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -376,7 +376,7 @@ class SimStepMultipleBase(unittest.TestCase):
 
         sim_trace = pyrtl.SimulationTrace()
         sim = self.sim(tracer=sim_trace)
-        sim.step_multiple({}, nsteps=5)
+        sim.step_multiple(nsteps=5)
 
         correct_output = ("--- Values in base 10 ---\n"
                           "b 0 1 2 3 4\n")
@@ -401,7 +401,7 @@ class SimStepMultipleBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace)
 
         with self.assertRaises(pyrtl.PyrtlError) as error:
-            sim.step_multiple({})
+            sim.step_multiple()
         self.assertEqual(str(error.exception),
                          'need to supply either input values '
                          'or a number of steps to simulate')


### PR DESCRIPTION
`step_multiple` has been changed so that the `provided_inputs` argument doesn't need to be supplied when there are no inputs to supply (versus previously, you would need to supply an empty map, `{}`). When it's not supplied, it requires that `nsteps` be specified instead. This is useful for testing designs without inputs (of which I've made a few recently, so this shorthand is useful).

I.e. you can do this:
```
import pyrtl

r = pyrtl.Register(2, 'r')
r.next <<= r + 1

sim = pyrtl.Simulation()
sim.step_multiple(nsteps=10)  # previously needed to be `sim.step_multiple({}, nsteps=10)`
sim.tracer.render_trace()
```

producing
```
  ▏0                        ▏5                       

r 0x0  ╳0x1 ╳0x2 ╳0x3 ╳0x0  ╳0x1 ╳0x2 ╳0x3 ╳0x0 ╳0x1 
```