### PR TITLE
Add check in simulation trace render for empty trace list

### DIFF
--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -62,6 +62,7 @@ class CompiledSimulation(object):
     at the cost of somewhat longer setup time.
     Generally this will do better than FastSimulation for simulations requiring over 1000 steps.
     It is not built to be a debugging tool, though it may help with debugging.
+    Note that only Input and Output wires can be traced using CompiledSimulation.
 
     In order to use this, you need:
         - A 64-bit processor

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1193,6 +1193,12 @@ class SimulationTrace(object):
                 DeprecationWarning)
             trace_list = [getattr(x, 'name', x) for x in trace_list]
 
+        if not trace_list:
+            raise PyrtlError(
+                "Empty trace list. This may have occurred because "
+                "untraceable wires were removed prior to simulation, "
+                "if a CompiledSimulation was used.")
+
         # print the 'ruler' which is just a list of 'ticks'
         # mapped by the pretty map
 

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -1005,6 +1005,20 @@ class TraceErrorBase(unittest.TestCase):
         with self.assertRaises(pyrtl.PyrtlError):
             self.sim_trace = pyrtl.SimulationTrace()
 
+    def test_empty_trace_after_untraceable_removed(self):
+        r = pyrtl.Register(2, 'r')
+        r.next <<= r + 1
+        sim = self.sim()
+        sim.step_multiple(provided_inputs={}, nsteps=10)
+        with self.assertRaises(pyrtl.PyrtlError) as ex:
+            sim.tracer.render_trace()
+        self.assertEquals(
+            str(ex.exception),
+            "Empty trace list. This may have occurred because "
+            "untraceable wires were removed prior to simulation, "
+            "if a CompiledSimulation was used."
+        )
+
     def test_invalid_base(self):
         self.in1 = pyrtl.Input(8, "in1")
         self.out = pyrtl.Output(8, "out")


### PR DESCRIPTION
There was an edge case that wasn't covered in the normal Simulation/SimulationTrace workflow: when a CompiledSimulation is instantiated, it creates a SimulationTrace if needed, followed by removing all untraceable wires from the trace list (in the CompiledSimulation's case, non-Input/Output wires or non-probes for Output wires). If a named register, for example, was part of the original trace list, the SimulationTrace object would be created fine, but after removing untraceable wires, the trace list would be empty. Then during rendering, it would throw a non-PyRTL exception.

This fixes that as well as adds a note about untraceable wires in CompiledSimulation's documentation.

See the added test for an example.