### PR TITLE
small update on verilog output

### DIFF
--- a/pyrtl/verilog.py
+++ b/pyrtl/verilog.py
@@ -140,7 +140,8 @@ def _to_verilog_header(file, block, varname):
                                                     memsize_str, m.name), file=file)
     for w in name_sorted(registers):
         print('    reg{:s} {:s};'.format(_verilog_vector_decl(w), varname(w)), file=file)
-    print('', file=file)
+    if (memories or registers):
+        print('', file=file)
 
     # wires
     for w in name_sorted(wires):
@@ -225,6 +226,9 @@ def _to_verilog_combinational(file, block, varname):
 
 def _to_verilog_sequential(file, block, varname):
     """ Print the sequential logic of the verilog implementation. """
+    if not block.logic_subset(op='r'):
+        return
+
     print('    // Registers', file=file)
     print('    always @( posedge clk )', file=file)
     print('    begin', file=file)

--- a/tests/test_verilog.py
+++ b/tests/test_verilog.py
@@ -4,8 +4,33 @@ import io
 import pyrtl
 from pyrtl import verilog
 
+verilog_output_small = """\
+// Generated automatically via PyRTL
+// As one initial test of synthesis, map to FPGA with:
+//   yosys -p "synth_xilinx -top toplevel" thisfile.v
 
-verilog_output = """\
+module toplevel(clk, o);
+    input clk;
+    output[12:0] o;
+
+    wire[3:0] const_0_12;
+    wire[2:0] const_1_3;
+    wire[5:0] const_2_38;
+    wire[12:0] tmp0;
+
+    // Combinational
+    assign const_0_12 = 12;
+    assign const_1_3 = 3;
+    assign const_2_38 = 38;
+    assign o = tmp0;
+    assign tmp0 = {const_0_12, const_1_3, const_2_38};
+
+endmodule
+
+"""
+
+
+verilog_output_large = """\
 // Generated automatically via PyRTL
 // As one initial test of synthesis, map to FPGA with:
 //   yosys -p "synth_xilinx -top toplevel" thisfile.v
@@ -609,7 +634,25 @@ class TestVerilog(unittest.TestCase):
         with io.StringIO() as testbuffer:
             pyrtl.output_to_verilog(testbuffer)
 
-    def test_textual_consistency(self):
+    def test_textual_consistency_small(self):
+        from pyrtl.wire import _reset_wire_indexers
+        from pyrtl.memory import _reset_memory_indexer
+
+        _reset_wire_indexers()
+        _reset_memory_indexer()
+
+        i = pyrtl.Const(0b1100)
+        j = pyrtl.Const(0b011, bitwidth=3)
+        k = pyrtl.Const(0b100110)
+        o = pyrtl.Output(13, 'o')
+        o <<= pyrtl.concat(i, j, k)
+
+        buffer = io.StringIO()
+        pyrtl.output_to_verilog(buffer)
+
+        self.assertEqual(buffer.getvalue(), verilog_output_small)
+
+    def test_textual_consistency_large(self):
         from pyrtl.wire import _reset_wire_indexers
         from pyrtl.memory import _reset_memory_indexer
 
@@ -646,7 +689,7 @@ class TestVerilog(unittest.TestCase):
         buffer = io.StringIO()
         pyrtl.output_to_verilog(buffer)
 
-        self.assertEqual(buffer.getvalue(), verilog_output)
+        self.assertEqual(buffer.getvalue(), verilog_output_large)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This simple change cleans up Verilog output by removing the section for register updates if there are no registers in the design, as well as removes an unneeded empty line when possible. 