### PR TITLE
Fix firrtl concat and select

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -103,6 +103,7 @@ from .passes import synthesize
 from .passes import nand_synth
 from .passes import and_inverter_synth
 from .passes import optimize
-
+from .passes import one_bit_selects
+from .passes import two_way_concat
 
 from .transform import net_transform, wire_transform, replace_wire, copy_block, clone_wire

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -10,7 +10,7 @@ from .core import working_block, set_working_block, _get_debug_mode, LogicNet, P
 from .helperfuncs import _NetCount
 from .corecircuits import (_basic_mult, _basic_add, _basic_sub, _basic_eq,
                            _basic_lt, _basic_gt, _basic_select, concat_list,
-                           as_wires)
+                           as_wires, concat)
 from .memory import MemBlock
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .wire import WireVector, Input, Output, Const, Register
@@ -523,6 +523,7 @@ def _decompose(net, wv_map, mems, block_out):
 def nand_synth(net):
     """
     Synthesizes an Post-Synthesis block into one consisting of nands and inverters in place
+
     :param block: The block to synthesize.
     """
     if net.op in '~nrwcsm@':
@@ -547,6 +548,7 @@ def nand_synth(net):
 def and_inverter_synth(net):
     """
     Transforms a decomposed block into one consisting of ands and inverters in place
+
     :param block: The block to synthesize
     """
     if net.op in '~&rwcsm@':
@@ -566,3 +568,70 @@ def and_inverter_synth(net):
         dest <<= ~(arg(0) & arg(1))
     else:
         raise PyrtlError("Op, '{}' is not supported in and_inv_synth".format(net.op))
+
+
+@transform.all_nets
+def two_way_concat(net):
+    """
+    Transforms a block such that all n-way (n > 2) concats are replaced
+    with series of 2-way concats.
+
+    :param block: The block to transform
+
+    This is useful for preparing the netlist for output to other formats, like
+    FIRRTL or BTOR2, whose 'concatenate' operation ('cat' and 'concat', respectively),
+    only allow two arguments (most-significant wire and least-significant wire).
+    """
+
+    # Turns a netlist of the form (where [] denote nets):
+    #
+    #  w1  w2  w3
+    #   |  |   |
+    #   [concat]
+    #      |
+    #      w4
+    #
+    # into:
+    #
+    #  w1 w2   w3
+    #   | |    |
+    # [concat] |
+    #      |   |
+    #     [concat]
+    #        |
+    #      [wire]
+    #        |
+    #        w4
+    if net.op != 'c':
+        return True
+
+    if len(net.args) <= 2:
+        return True
+
+    w = concat(net.args[0], net.args[1])
+    for a in net.args[2:]:
+        w = concat(w, a)
+
+    dest = net.dests[0]
+    dest <<= w
+
+
+@transform.all_nets
+def one_bit_selects(net):
+    """
+    Converts arbitrary-sliced selects to concatenations of 1-bit selects
+
+    :param block: The block to transform
+
+    This is useful for preparing the netlist for output to other formats, like
+    FIRRTL or BTOR2, whose 'select' operation ('bits' and 'slice', respectively)
+    require contiguous ranges. Python slices are not necessarily contiguous ranges,
+    e.g. the range [::2] (syntactic sugar for slice(None, None, 2)) produces indices
+    0, 2, 4, etc. up to the length of the list on which it is used.
+    """
+    if net.op != 's':
+        return True
+
+    catlist = [net.args[0][i] for i in net.op_param]
+    dest = net.dests[0]
+    dest <<= concat_list(catlist)

--- a/pyrtl/verilog.py
+++ b/pyrtl/verilog.py
@@ -14,6 +14,7 @@ from .core import working_block, _NameSanitizer
 from .wire import WireVector, Input, Output, Const, Register
 from .corecircuits import concat
 from .memory import RomBlock
+from .inputoutput import _name_sorted, _net_sorted
 
 
 # ----------------------------------------------------------------
@@ -93,20 +94,11 @@ def _verilog_block_parts(block):
     return inputs, outputs, registers, wires, memories
 
 
-def _natural_sort_key(key):
-    """ Convert the key into a form such that it will be sorted naturally,
-        e.g. such that "tmp4" appears before "tmp18".
-    """
-    def convert(text):
-        return int(text) if text.isdigit() else text
-    return [convert(c) for c in re.split(r'(\d+)', key)]
-
-
 def _to_verilog_header(file, block, varname):
     """ Print the header of the verilog implementation. """
 
     def name_sorted(wires):
-        return sorted(wires, key=lambda w: _natural_sort_key(varname(w)))
+        return _name_sorted(wires, name_mapper=varname)
 
     def name_list(wires):
         return [varname(w) for w in wires]
@@ -161,24 +153,11 @@ def _to_verilog_header(file, block, varname):
         print('', file=file)
 
 
-def _net_sorted(logic, varname):
-    def natural_keys(n):
-        if n.op == '@':
-            # Sort based on the name of the wr_en wire, since
-            # this particular net is used within 'always begin ... end'
-            # blocks for memory update logic.
-            key = str(n.args[2])
-        else:
-            key = varname(n.dests[0])
-        return _natural_sort_key(key)
-    return sorted(logic, key=natural_keys)
-
-
 def _to_verilog_combinational(file, block, varname):
     """ Print the combinational logic of the verilog implementation. """
 
     def name_sorted(wires):
-        return sorted(wires, key=lambda w: _natural_sort_key(varname(w)))
+        return _name_sorted(wires, name_mapper=varname)
 
     print('    // Combinational', file=file)
 

--- a/tests/test_inputoutput.py
+++ b/tests/test_inputoutput.py
@@ -442,5 +442,92 @@ class TestOutputIPynb(unittest.TestCase):
         htmlstring = inputoutput.trace_to_html(sim_trace)  # tests if it compiles or not
 
 
+firrtl_output_concat_test = """\
+circuit Example :
+  module Example :
+    input clock : Clock
+    input reset : UInt<1>
+    output o : UInt<13>
+    wire tmp0 : UInt<13>
+    wire tmp1 : UInt<7>
+    wire tmp2 : UInt<13>
+    node const_0_12 = UInt<4>(12)
+    node const_1_3 = UInt<3>(3)
+    node const_2_38 = UInt<6>(38)
+
+    o <= tmp0
+    tmp0 <= tmp2
+    tmp1 <= cat(const_0_12, const_1_3)
+    tmp2 <= cat(tmp1, const_2_38)
+"""
+
+firrtl_output_select_test = """\
+circuit Example :
+  module Example :
+    input clock : Clock
+    input reset : UInt<1>
+    output b : UInt<6>
+    wire tmp0 : UInt<6>
+    wire tmp1 : UInt<1>
+    wire tmp2 : UInt<1>
+    wire tmp3 : UInt<1>
+    wire tmp4 : UInt<1>
+    wire tmp5 : UInt<1>
+    wire tmp6 : UInt<1>
+    wire tmp7 : UInt<6>
+    wire tmp8 : UInt<2>
+    wire tmp9 : UInt<3>
+    wire tmp10 : UInt<4>
+    wire tmp11 : UInt<5>
+    wire tmp12 : UInt<6>
+    node const_0_2893 = UInt<12>(2893)
+
+    b <= tmp0
+    tmp0 <= tmp7
+    tmp1 <= bits(const_0_2893, 0, 0)
+    tmp2 <= bits(const_0_2893, 2, 2)
+    tmp3 <= bits(const_0_2893, 4, 4)
+    tmp4 <= bits(const_0_2893, 6, 6)
+    tmp5 <= bits(const_0_2893, 8, 8)
+    tmp6 <= bits(const_0_2893, 10, 10)
+    tmp7 <= tmp12
+    tmp8 <= cat(tmp6, tmp5)
+    tmp9 <= cat(tmp8, tmp4)
+    tmp10 <= cat(tmp9, tmp3)
+    tmp11 <= cat(tmp10, tmp2)
+    tmp12 <= cat(tmp11, tmp1)
+"""
+
+
+class TestOutputFirrtl(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+        pyrtl.wire._reset_wire_indexers()
+        pyrtl.memory._reset_memory_indexer()
+
+    def test_textual_consistency_concats(self):
+        i = pyrtl.Const(0b1100)
+        j = pyrtl.Const(0b011, bitwidth=3)
+        k = pyrtl.Const(0b100110)
+        o = pyrtl.Output(13, 'o')
+        o <<= pyrtl.concat(i, j, k)
+
+        buffer = io.StringIO()
+        pyrtl.output_to_firrtl(buffer)
+
+        self.assertEqual(buffer.getvalue(), firrtl_output_concat_test)
+
+    def test_textual_consistency_selects(self):
+        a = pyrtl.Const(0b101101001101)
+        b = pyrtl.Output(6, 'b')
+        b <<= a[::2]
+
+        buffer = io.StringIO()
+        pyrtl.output_to_firrtl(buffer)
+
+        print(buffer.getvalue())
+        self.assertEqual(buffer.getvalue(), firrtl_output_select_test)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verilog.py
+++ b/tests/test_verilog.py
@@ -596,6 +596,11 @@ class TestVerilogNames(unittest.TestCase):
 class TestVerilog(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()
+        # To compare textual consistency, need to make
+        # sure we're starting at the same index for all
+        # automatically created names.
+        pyrtl.wire._reset_wire_indexers()
+        pyrtl.memory._reset_memory_indexer()
 
     def test_romblock_does_not_throw_error(self):
         from pyrtl.corecircuits import _basic_add
@@ -610,15 +615,6 @@ class TestVerilog(unittest.TestCase):
             pyrtl.output_to_verilog(testbuffer)
 
     def test_textual_consistency(self):
-        from pyrtl.wire import _reset_wire_indexers
-        from pyrtl.memory import _reset_memory_indexer
-
-        # To compare textual consistency, need to make
-        # sure we're starting at the same index for all
-        # automatically created names.
-        _reset_wire_indexers()
-        _reset_memory_indexer()
-
         # The following is a non-sensical program created to test
         # that the Verilog that is created is deterministic
         # in the order in which it presents the wire, register,


### PR DESCRIPTION
As I was looking at other output formats/IRs, I found that the FIRRTL output created by PyRTL is wrong, specifically with concatenation and select.

# Concatenation
## Problem
The problem with concatenation is that the FIRRTL creation code was assuming that the PyRTL `c` nets only had two argument wires, when in reality the number of wires is arbitrary.

Given the following PyRTL code:
```python
i = pyrtl.Const(0b1100)
j = pyrtl.Const(0b011, bitwidth=3)
k = pyrtl.Const(0b100110)
o = pyrtl.Output(13, 'o')
o <<= pyrtl.concat(i, j, k)

sim = pyrtl.Simulation()
sim.step({})
assert sim.inspect('o') == 0b1100011100110
```

`output_to_firrtl()` was creating:
```firrtl
circuit Example : 
  module Example : 
    input clock : Clock
    input reset : UInt<1>
    output o : UInt<13>
    node const_2_38 = UInt<6>(38)
    node const_0_12 = UInt<4>(12)
    node const_1_3 = UInt<3>(3)
    wire tmp0 : UInt<13>

    o <= tmp0
    tmp0 <= cat(const_0_12, const_1_3)
```

Notice how `tmp0` is the result of only concatenating the upper two wires, when it should be all three.

## Solution
The solution was to convert each n-way concatenation (n > 2) into n-2 cascading concatenations. This way, it translates directly to the FIRRTL `cat` operator, which requires exactly two argument wires.

So `output_to_firrtl()` now produces:
```firrtl
circuit Example :
  module Example :
    input clock : Clock
    input reset : UInt<1>
    output o : UInt<13>
    wire tmp0 : UInt<13>
    wire tmp1 : UInt<7>
    wire tmp2 : UInt<13>
    node const_0_12 = UInt<4>(12)
    node const_1_3 = UInt<3>(3)
    node const_2_38 = UInt<6>(38)

    o <= tmp0
    tmp0 <= tmp2
    tmp1 <= cat(const_0_12, const_1_3)
    tmp2 <= cat(tmp1, const_2_38)
```

# Selection
## Problem
The problem with selection was that the FIRRTL creation code was assuming that the slice for each PyRTL `s` net represented a contiguous set of bits, but in reality, it's a standard Python slice, which is not necessarily contiguous (e.g. `slice(None, None, 2)` represents stepping every other index).

Given the following PyRTL code:
```python
a = pyrtl.Const(0b101101001101)
b = pyrtl.Output(6, 'b')
b <<= a[::2]

sim = pyrtl.Simulation()
sim.step({})
assert sim.inspect('b') == 0b00011011  # 27
```

`output_to_firrtl()` was creating:
```firrtl
circuit Example : 
  module Example : 
    input clock : Clock
    input reset : UInt<1>
    output b : UInt<6>
    node const_0_2893 = UInt<12>(2893)
    wire tmp0 : UInt<6>

    b <= tmp0
    tmp0 <= bits(const_0_2893, 10, 0)
```
Note that `tmp0` is getting bits 0 through 10 of that constant, when it should be getting bits 0, 2, 4, 6, 8, and 10.

## Solution

One solution (probably the easiest) is to turn arbitrary-sliced selects into concatenations of 1-bit selects. This way we're guaranteed all `s` logic net slices are trivially contiguous since they're one bit.

`output_to_firrtl()` now creates:
```firrtl
circuit Example :
  module Example :
    input clock : Clock
    input reset : UInt<1>
    output b : UInt<6>
    wire tmp0 : UInt<6>
    wire tmp1 : UInt<1>
    wire tmp2 : UInt<1>
    wire tmp3 : UInt<1>
    wire tmp4 : UInt<1>
    wire tmp5 : UInt<1>
    wire tmp6 : UInt<1>
    wire tmp7 : UInt<6>
    wire tmp8 : UInt<2>
    wire tmp9 : UInt<3>
    wire tmp10 : UInt<4>
    wire tmp11 : UInt<5>
    wire tmp12 : UInt<6>
    node const_0_2893 = UInt<12>(2893)

    b <= tmp0
    tmp0 <= tmp7
    tmp1 <= bits(const_0_2893, 0, 0)
    tmp2 <= bits(const_0_2893, 2, 2)
    tmp3 <= bits(const_0_2893, 4, 4)
    tmp4 <= bits(const_0_2893, 6, 6)
    tmp5 <= bits(const_0_2893, 8, 8)
    tmp6 <= bits(const_0_2893, 10, 10)
    tmp7 <= tmp12
    tmp8 <= cat(tmp6, tmp5)
    tmp9 <= cat(tmp8, tmp4)
    tmp10 <= cat(tmp9, tmp3)
    tmp11 <= cat(tmp10, tmp2)
    tmp12 <= cat(tmp11, tmp1)
```

# Testing
I added test cases for these, including tests that check simulation after just the transformation passes. I also checked that Verilog code generated by the FIRRTL toolchain, given the PyRTL-produced FIRRTL code, is correct.

This the Verilog produced by `firrtl` when given the FIRRTL code that PyRTL produced for the `concat`-related PyRTL code above:
```> firrtl -i concats.fir -o concats_firrtl-out.v -X verilog```
```firrtl
module Example(
  input         clock,
  input         reset,
  output [12:0] o
);
  assign o = 13'h18e6;
endmodule
```
`13'h18e6` is indeed expected.

Similarly, the Verilog produced by `firrtl` given the PyRTL-produced FIRRTL code for the `select` test code above is:
```> firrtl -i selects.fir -o selects_firrtl-out.v -X verilog```

```firrtl
module Example(
  input        clock,
  input        reset,
  output [5:0] b
);
  assign b = 6'h1b;
endmodule
```
`6'h1b` is indeed expected.