### PR TITLE
Add block to net transform calls in firrtl output call

### DIFF
--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -275,12 +275,12 @@ def output_to_firrtl(open_file, rom_blocks=None, block=None):
     # FIRRTL only allows 'bits' operations to have two parameters: a high and low
     # index representing the inclusive bounds of a contiguous range. PyRTL uses
     # slice syntax, which aren't always contiguous, so we need to convert them.
-    one_bit_selects()  # pylint: disable=no-value-for-parameter
+    one_bit_selects(block=block)  # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
 
     # FIRRTL only allows 'concatenate' operations to have two arguments,
     # but PyRTL's 'c' op allows an arbitrary number of wires. We need to convert
     # these n-way concats to series of two-way concats accordingly.
-    two_way_concat()  # pylint: disable=no-value-for-parameter
+    two_way_concat(block=block)  # pylint: disable=no-value-for-parameter,unexpected-keyword-arg
 
     f = open_file
     # write out all the implicit stuff


### PR DESCRIPTION
This is a minor follow-on to the recent FIRRTL output update, adding in the passed in block to the net transform calls.