### PR TITLE
Output extra edge info always when present in map

### DIFF
--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -537,14 +537,14 @@ def _default_edge_namer(edge, is_to_splitmerge=False, extra_edge_info=None):
              in to block_to_graphviz_string
     """
 
-    if (edge.name is None
-            or (edge.name.startswith('tmp') and not extra_edge_info)
-            or isinstance(edge, (Input, Output, Const, Register))):
+    name = '' if edge.name is None else '/'.join([edge.name, str(len(edge))])
+    if extra_edge_info and edge in extra_edge_info:
+        # Always label an edge if present in the extra_edge_info map
+        name = name + " (" + str(extra_edge_info[edge]) + ")"
+    elif (edge.name is None
+          or edge.name.startswith('tmp')
+          or isinstance(edge, (Input, Output, Const, Register))):
         name = ''
-    else:
-        name = '/'.join([edge.name, str(len(edge))])
-        if extra_edge_info and edge in extra_edge_info:
-            name = name + " (" + str(extra_edge_info[edge]) + ")"
 
     penwidth = 2 if len(edge) == 1 else 6
     arrowhead = 'none' if is_to_splitmerge else 'normal'


### PR DESCRIPTION
Slight internal update to graphviz edge namer, to always output edge info for an edge if it's present in the user-provided map.

E.g. I have an edge namer that prints the type of edge/wire next to the wire. Given the following PyRTL:
```python
import pyrtl

a = pyrtl.Input(2, 'a')
b = pyrtl.Input(2, 'b')
c = pyrtl.Output(3, 'c')
c <<= a + b - 1

info = {e: e.name + str(type(e)) for e in pyrtl.working_block().wirevector_set}

namer = pyrtl.inputoutput.graphviz_detailed_namer(extra_edge_info=info)

with open("graph-out.gv", "w") as f:
    pyrtl.output_to_graphviz(f, namer=namer, split_state=False)
```

Before, it wouldn't print it out for inputs/constants/outputs:

![graph-out_old](https://user-images.githubusercontent.com/2482771/106078607-8968bb00-60c8-11eb-8dbe-3d18e4a01827.png)

and the new version:

![graph-out](https://user-images.githubusercontent.com/2482771/106078622-8f5e9c00-60c8-11eb-84f3-a833770f6be2.png)
