### PR TITLE
Fix textual netlist output in jupyter notebooks

### DIFF
--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -698,10 +698,10 @@ def _currently_in_jupyter_notebook():
 def _print_netlist_latex(netlist):
     """ Print each net in netlist in a Latex array """
     from IPython.display import display, Latex  # pylint: disable=import-error
-    out = r'\n\\begin{array}{ \| c \| c \| l \| }\n'
-    out += r'\n\hline\n'
-    out += r'\\hline\n'.join(str(n) for n in netlist)
-    out += r'\hline\n\\end{array}\n'
+    out = '\n\\begin{array}{ \\| c \\| c \\| l \\| }\n'
+    out += '\n\\hline\n'
+    out += '\\hline\n'.join(str(n) for n in netlist)
+    out += '\\hline\n\\end{array}\n'
     display(Latex(out))
 
 


### PR DESCRIPTION
This updates the Latex output for the block when outputting in a Jupyter Notebook. In [this](https://github.com/pllab/PyRTL/commit/83706f0b8b225421872e257ba47e8b013877dcbb#diff-152e4130145ecb83900318841908b034000d6a2842964a8a6be46fcac6f61f3eR668) commit I mistakenly prefixed the string with `r` to appease `tox`. This commit fixes the problem:

Before:
<img width="1063" alt="Screen Shot 2021-02-09 at 10 38 35 AM" src="https://user-images.githubusercontent.com/2482771/107411131-0af61b00-6ac3-11eb-818c-a731a4c39589.png">

After:
<img width="1063" alt="Screen Shot 2021-02-09 at 10 38 55 AM" src="https://user-images.githubusercontent.com/2482771/107411125-0893c100-6ac3-11eb-9918-216e69bff6ce.png">