### PR TITLE
Fix FastSimulation to work with IntEnums

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -710,7 +710,7 @@ class FastSimulation(object):
         if isinstance(wire, (Input, Register)):
             return 'd[' + repr(wire.name) + ']'  # passed in
         elif isinstance(wire, Const):
-            return str(wire.val)  # hardcoded
+            return str(int(wire.val))  # hardcoded
         else:
             return self._varname(wire)
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -274,6 +274,32 @@ class SimWithSpecialWiresBase(unittest.TestCase):
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
+    def test_consts_from_int_enums(self):
+        from enum import IntEnum
+
+        class MyEnum(IntEnum):
+            A = 0
+            B = 1
+            C = 3
+
+        i = pyrtl.Input(max(MyEnum).bit_length(), 'i')
+        o = pyrtl.Output(1, 'o')
+        with pyrtl.conditional_assignment:
+            with (i == MyEnum.A) | (i == MyEnum.B):
+                o |= 0
+            with pyrtl.otherwise:
+                o |= 1
+
+        trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=trace)
+
+        sim.step({'i': MyEnum.A})
+        self.assertEqual(sim.inspect(o), 0)
+        sim.step({'i': MyEnum.B})
+        self.assertEqual(sim.inspect(o), 0)
+        sim.step({'i': MyEnum.C})
+        self.assertEqual(sim.inspect(o), 1)
+
 
 class SimInputValidationBase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A small error occurs when using FastSimulation when they're are Consts that were created using an IntEnum.

For example, given:
```python
from enum import IntEnum
import pyrtl

class Causes(IntEnum):
    BadAddress = 0
    IllegalInstruction = 1
    Timeout = 3

i = pyrtl.Input(max(Causes).bit_length(), 'i')
o = pyrtl.Output(1, 'o')

with pyrtl.conditional_assignment:
    with (i == Causes.BadAddress) | (i == Causes.IllegalInstruction):
        o |= 0
    with pyrtl.otherwise:
        o |= 1

sim = pyrtl.FastSimulation()
sim.step_multiple({
    'i': [v for v in Causes]
})
sim.tracer.render_trace()
```

The error that is occurs is:
```bash
Traceback (most recent call last):
  File "ex1.py", line 18, in <module>
    sim.step_multiple({
  File "/Users/michael/PyRTL/pyrtl/simulation.py", line 632, in step_multiple
    self.step({w: int(v[i]) for w, v in provided_inputs.items()})
  File "/Users/michael/PyRTL/pyrtl/simulation.py", line 537, in step
    self.regs, self.outs, mem_writes = self.sim_func(ins)
  File "<string>", line 7, in sim_func
NameError: name 'Causes' is not defined
```

This occurs because the FastSimulation outputs constants to the Python file being created with `str`, which in the case of Consts created using IntEnums, will produce the name of the particular Enum member, rather than the value associated with it. The solution is to wrap the Const's value in an `int` before converting to a string. This allows us to maintain the associativity between Consts and the Enum value used to create them.

Now the above produces:
```bash
  ▏0                       

i 0x0  ╳0x1 ╳0x3 

o __________╱‾‾‾‾

```
as expected.