### PR TITLE
Make FastSimulation behave like Simulation and CompiledSimulation when named constants exist

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -849,9 +849,9 @@ class FastSimulation(object):
         if self.tracer is not None:
             for wire_name in self.tracer.trace:
                 wire = self.block.wirevector_by_name[wire_name]
-                if not isinstance(wire, (Input, Const, Register, Output)):
-                    v_wire_name = self._varname(wire)
-                    prog.append('    outs["%s"] = %s' % (wire_name, v_wire_name))
+                if not isinstance(wire, (Input, Register, Output)):
+                    value = int(wire.val) if isinstance(wire, Const) else self._varname(wire)
+                    prog.append('    outs["%s"] = %s' % (wire_name, value))
 
         prog.append("    return regs, outs, mem_ws")
         return '\n'.join(prog)


### PR DESCRIPTION
The issue is the following: PyRTL currently doesn't officially support explicitly-named constants, but you can easily give them a new name after creation:

```python
c = pyrtl.Const(1)
c.name = "my_constant"
```

Disregarding the fact that doing this probably breaks the `wirevector_by_name` map that is stored in the block for performance reasons (officially supported named Constants would be another PR), doing the above currently works in Simulation and CompiledSimulation, but breaks FastSimulation.

This PR updates FastSimulation to behave like the other two simulation frameworks in this edge case.

Given this

```python
from enum import IntEnum
import pyrtl

if __name__ == "__main__":
    i = pyrtl.Input(1, 'i')
    o = pyrtl.Output(2, 'o')

    c = pyrtl.Const(3)
    c.name = "my_constant"
    o <<= i + c

    tracer = pyrtl.SimulationTrace()
    sim = pyrtl.FastSimulation()
    sim.step_multiple({
        'i': [0, 1]
    })
    sim.tracer.render_trace()
```

## Before
```bash
Traceback (most recent call last):
  File "ex5.py", line 18, in <module>
    sim.step_multiple({
  File "/Users/michael/PyRTL/pyrtl/simulation.py", line 632, in step_multiple
    self.step({w: int(v[i]) for w, v in provided_inputs.items()})
  File "/Users/michael/PyRTL/pyrtl/simulation.py", line 546, in step
    self.tracer.add_fast_step(self)
  File "/Users/michael/PyRTL/pyrtl/simulation.py", line 1036, in add_fast_step
    self.trace[wire_name].append(fastsim.context[wire_name])
KeyError: 'my_constant'
```

## After (now the same for all 3 simulation frameworks)
 ```bash
> python3 ex5.py
            ▏0                       

          i _____╱‾‾‾‾

my_constant 0x3       

          o 0x3  ╳0x0 
```