### PR TITLE
Adding option to name constants

### DIFF
--- a/pyrtl/inputoutput.py
+++ b/pyrtl/inputoutput.py
@@ -558,7 +558,8 @@ def _default_node_namer(node, split_state=False, extra_node_info=None):
         return v
 
     if isinstance(node, Const):
-        return '[label="%d", shape=circle, fillcolor=lightgrey]' % label(node.val)
+        name = node.name + ': ' if not node.name.startswith('const_') else ''
+        return '[label="%s", shape=circle, fillcolor=lightgrey]' % label(name + str(node.val))
     elif isinstance(node, Input):
         return '[label="%s", shape=invhouse, fillcolor=coral]' % label(node.name)
     elif isinstance(node, Output):

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -992,7 +992,7 @@ class SimulationTrace(object):
         self.block = working_block(block)
 
         def is_internal_name(name):
-            return (name.startswith('tmp') or name.startswith('const')
+            return (name.startswith('tmp') or name.startswith('const_')
                     # or name.startswith('synth_')
                     or name.endswith("'"))
 

--- a/pyrtl/transform.py
+++ b/pyrtl/transform.py
@@ -179,7 +179,9 @@ def clone_wire(old_wire, name=None):
     same name in the same block is not allowed
     """
     if isinstance(old_wire, Const):
-        return Const(old_wire.val, old_wire.bitwidth)
+        if name is None:
+            return Const(old_wire.val, old_wire.bitwidth, name=old_wire.name)
+        return Const(old_wire.val, old_wire.bitwidth, name=name)
     else:
         if name is None:
             return old_wire.__class__(old_wire.bitwidth, name=old_wire.name)

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -579,10 +579,10 @@ class Const(WireVector):
 
     _code = 'C'
 
-    def __init__(self, val, bitwidth=None, signed=False, block=None):
+    def __init__(self, val, bitwidth=None, name='', signed=False, block=None):
         """ Construct a constant implementation at initialization
 
-        :param int, bool, or str val: The value for the const wirevector
+        :param int, bool, or str val: the value for the const wirevector
         :param int: the desired bitwidth of the resulting const
         :param signed: specify if bits should be used for twos complement
         :return: a wirevector object representing a const wire
@@ -611,7 +611,7 @@ class Const(WireVector):
                 'constant %d returned by infer_val_and_bitwidth somehow not fitting in %d bits'
                 % (num, bitwidth))
 
-        name = _constIndexer.make_valid_string() + '_' + str(val)
+        name = name if name else _constIndexer.make_valid_string() + '_' + str(val)
 
         super(Const, self).__init__(bitwidth=bitwidth, name=name, block=block)
         # add the member "val" to track the value of the constant

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -300,6 +300,25 @@ class SimWithSpecialWiresBase(unittest.TestCase):
         sim.step({'i': MyEnum.C})
         self.assertEqual(sim.inspect(o), 1)
 
+    def test_named_consts(self):
+        in1 = pyrtl.Input(8, "in1")
+        c1 = pyrtl.Const(1, 1, "c1")
+        out1 = pyrtl.Output(16, "out1")
+        out1 <<= in1 + c1
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+        for i in range(10):
+            sim.step({
+                'in1': 2 * i,
+            })
+        correct_outp = (" --- Values in base 10 ---\n"
+                        "c1    1  1  1  1  1  1  1  1  1  1\n"
+                        "in1   0  2  4  6  8 10 12 14 16 18\n"
+                        "out1  1  3  5  7  9 11 13 15 17 19\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_outp)
+
 
 class SimInputValidationBase(unittest.TestCase):
     def setUp(self):

--- a/tests/test_verilog.py
+++ b/tests/test_verilog.py
@@ -15,15 +15,15 @@ module toplevel(clk, o);
 
     wire[3:0] const_0_12;
     wire[2:0] const_1_3;
-    wire[5:0] const_2_38;
+    wire[5:0] k;
     wire[12:0] tmp0;
 
     // Combinational
     assign const_0_12 = 12;
     assign const_1_3 = 3;
-    assign const_2_38 = 38;
+    assign k = 38;
     assign o = tmp0;
-    assign tmp0 = {const_0_12, const_1_3, const_2_38};
+    assign tmp0 = {const_0_12, const_1_3, k};
 
 endmodule
 
@@ -642,7 +642,7 @@ class TestVerilog(unittest.TestCase):
     def test_textual_consistency_small(self):
         i = pyrtl.Const(0b1100)
         j = pyrtl.Const(0b011, bitwidth=3)
-        k = pyrtl.Const(0b100110)
+        k = pyrtl.Const(0b100110, name='k')
         o = pyrtl.Output(13, 'o')
         o <<= pyrtl.concat(i, j, k)
 

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -316,6 +316,18 @@ class TestConst(unittest.TestCase):
             c = pyrtl.Const(4)
             c <<= 3
 
+    def test_named(self):
+        block = pyrtl.working_block()
+        c = pyrtl.Const(20, name="archid")
+        self.assertIn("archid", block.wirevector_by_name)
+        self.assertIn(c, block.wirevector_set)
+        self.assertEqual(c.val, 20)
+        c.name = "vendorid"
+        self.assertNotIn("archid", block.wirevector_by_name)
+        self.assertIn("vendorid", block.wirevector_by_name)
+        self.assertIn(c, block.wirevector_set)
+        self.assertEqual(c.val, 20)
+
     def check_const(self, val_in, expected_val, expected_bitwidth, **kargs):
         c = pyrtl.Const(val_in, **kargs)
         self.assertEqual(c.val, expected_val)


### PR DESCRIPTION
This change officially allows constants to be given user-defined names.

The reasons why this might be desired:

* It's consistent with how we can name all other WireVectors and Memories
* Constants whose name have significant meaning (like archid, vendorid in the case of a RISC-V processor) will be reflected in various forms of output like Verilog and graphviz
* By being able to name constants explicitly, they will be automatically added to the traces (unless otherwise specified), again consistent with other WireVectors

One difference that might trip people up between naming constants and naming other wirevectors is that the name argument for constants is third, which I think is most natural (since the first argument is the constant value and the second is the bitwidth). The name follows the bitwidth like all other WireVector initializers, so it's consistent in that respect:

```python
pyrtl.Const(42, 16, "mySpecialConst")
# compared to
pyrtl.WireVector(16, "myWire")
pyrtl.Register(16, "myReg")
# etc.
```

It also modifies how named constants are presented in svg/graphviz output.

For example, given:
```python
import pyrtl

i = pyrtl.Const(0b1100)
j = pyrtl.Const(0b011, bitwidth=3)
k = pyrtl.Const(0b100110, name='k')
o = pyrtl.Output(13, 'o')
o <<= pyrtl.concat(i, j, k)

with open("consts.svg", "w") as f:
    pyrtl.output_to_svg(f)

with open("consts.gv", "w") as f:
    pyrtl.output_to_graphviz(f)
```

It produces:
![consts](https://user-images.githubusercontent.com/2482771/109342956-7a893b80-7821-11eb-9cf3-895b1be5c8a4.png)
