### PR TITLE
Keep user-defined const name after synthesis; error in simulation if only named wires are Consts

### DIFF
--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -408,7 +408,7 @@ def synthesize(update_working_block=True, block=None):
                 new_name = '_'.join((wirevector.name, 'synth', str(i)))
                 if isinstance(wirevector, Const):
                     new_val = (wirevector.val >> i) & 0x1
-                    new_wirevector = Const(bitwidth=1, val=new_val)
+                    new_wirevector = Const(name=new_name, bitwidth=1, val=new_val)
                 elif isinstance(wirevector, (Input, Output)):
                     new_wirevector = WireVector(name="tmp_" + new_name, bitwidth=1)
                 else:

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1001,8 +1001,9 @@ class SimulationTrace(object):
         elif wires_to_track == 'all':
             wires_to_track = self.block.wirevector_set
 
-        if not len(wires_to_track):
-            raise PyrtlError("There needs to be at least one named wire "
+        non_const_tracked = list(filter(lambda w: not isinstance(w, Const), wires_to_track))
+        if not len(non_const_tracked):
+            raise PyrtlError("There needs to be at least one named non-constant wire "
                              "for simulation to be useful")
         self.wires_to_track = wires_to_track
         self.trace = TraceStorage(wires_to_track)


### PR DESCRIPTION
This adds a few named-constant related changes from #321:
* During synthesis, retain name of const in newly generated wire
* Disallow simulation unless there is a non-Constant named wirevector, since constants don't change during simulation and so simulation wouldn't be useful (matches the previous behavior)

This adds the `synth` substring into synthesized constant names. Is this acceptable?