### PR TITLE
Remove extraneous print in unit test

### DIFF
--- a/tests/test_inputoutput.py
+++ b/tests/test_inputoutput.py
@@ -525,7 +525,6 @@ class TestOutputFirrtl(unittest.TestCase):
         buffer = io.StringIO()
         pyrtl.output_to_firrtl(buffer)
 
-        print(buffer.getvalue())
         self.assertEqual(buffer.getvalue(), firrtl_output_select_test)
 
 


### PR DESCRIPTION
Looks like a `print` call was left in a unit test. This simply removes it.