### PR TITLE
Change tox python version from 3.4 to 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-# don't forget to change the .travis.yml file when changing
-# the following line
-envlist = py{34,27}-{test}, pycodestyle
+# don't forget to change the [gh-actions] 'python' variable and the
+# .github/workflows/python-package.yml 'python-version' value when changing the following line
+envlist = py{37,27}-{test}, pycodestyle
 
 [gh-actions]
 python =
     2.7: py27
-    3.4: py34, pycodestyle
+    3.7: py37, pycodestyle
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
tox-gh-actions isn't supported with Python 3.4. For simplicity, we'd like the `tox.ini` file to be fully supported by the gh-action flow, so this PR changes back the Python 3 version used for continuous integration to 3.7.