### PR TITLE
GitHub actions update

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-# don't forget to change the .travis.yml file when changing
-# the following line
-envlist = py{34,27}-{test}, pycodestyle
+# don't forget to change the [gh-actions] 'python' variable and the
+# .github/workflows/python-package.yml 'python-version' value when changing the following line
+envlist = py{37,27}-{test}, pycodestyle
 
 [gh-actions]
 python =
     2.7: py27
-    3.4: py34, pycodestyle
+    3.7: py37, pycodestyle
 
 [testenv]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-# don't forget to change the [gh-actions] 'python' variable and the
+# don't forget to change the [gh-actions] 'python' and [testenv] envdir variables and the
 # .github/workflows/python-package.yml 'python-version' value when changing the following line
 envlist = py{37,27}-{test}, pycodestyle
 
@@ -17,7 +17,7 @@ deps = test: -rrequirements.txt
 
 envdir =
     py27: {toxworkdir}/27
-    py34: {toxworkdir}/34
+    py37: {toxworkdir}/37
     pycodestyle: {toxworkdir}/pycodestyle
 
 setenv =


### PR DESCRIPTION
tox-gh-actions isn't supported with Python 3.4. For simplicity, we'd like the tox.ini file to be fully supported by the gh-action flow, so this PR changes back the Python 3 version used for continuous integration to 3.7.