### PR TITLE
Expand functionality of matching bitpattern to include fields

### DIFF
--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -285,6 +285,28 @@ class TestMatchBitpattern(unittest.TestCase):
             'r 036912151821\n'
         )
 
+    def test_match_bitwidth_with_pattern_matched_fields(self):
+        i = pyrtl.Input(5, 'i')
+        out = pyrtl.Output(2, 'out')
+
+        with pyrtl.conditional_assignment:
+            with pyrtl.match_bitpattern(i, '1a?a0') as (a,):
+                out |= a
+            with pyrtl.match_bitpattern(i, 'b0?1b') as (b,):
+                out |= b
+            with pyrtl.match_bitpattern(i, 'ba1ab') as (b, a):
+                out |= a + b
+
+        sim = pyrtl.Simulation()
+        sim.step_multiple({'i': [0b11010, 0b00011, 0b01101]})
+        output = six.StringIO()
+        sim.tracer.print_trace(output, compact=True)
+        self.assertEqual(
+            output.getvalue(),
+            '  i 26313\n'
+            'out 313\n'
+        )
+
 
 class TestChop(unittest.TestCase):
     def setUp(self):

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -307,6 +307,28 @@ class TestMatchBitpattern(unittest.TestCase):
             'out 313\n'
         )
 
+    def test_match_bitwidth_with_pattern_matched_fields_by_name(self):
+        i = pyrtl.Input(5, 'i')
+        out = pyrtl.Output(2, 'out')
+
+        with pyrtl.conditional_assignment:
+            with pyrtl.match_bitpattern(i, '1a?a0') as x:
+                out |= x.a
+            with pyrtl.match_bitpattern(i, 'b0?1b') as x:
+                out |= x.b
+            with pyrtl.match_bitpattern(i, 'ba1ab') as x:
+                out |= x.a + x.b
+
+        sim = pyrtl.Simulation()
+        sim.step_multiple({'i': [0b11010, 0b00011, 0b01101]})
+        output = six.StringIO()
+        sim.tracer.print_trace(output, compact=True)
+        self.assertEqual(
+            output.getvalue(),
+            '  i 26313\n'
+            'out 313\n'
+        )
+
 
 class TestChop(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR expands the functionality of `match_bitpattern` to 1) return the fields that are matched when non-`?` characters are used as wildcards in the pattern and 2) allow the fields to be pattern-matched against tuples in `with` statements:

Here's a small example:
```python
import pyrtl

i = pyrtl.Input(5, 'i')
out = pyrtl.Output(2, 'out')

with pyrtl.conditional_assignment:
    with pyrtl.match_bitpattern(i, '1a?a0') as (a,):
        out |= a
    with pyrtl.match_bitpattern(i, 'b0?1b') as (b,):
        out |= b
    with pyrtl.match_bitpattern(i, 'ba1ab') as (b, a):
        out |= a + b

sim = pyrtl.Simulation()
sim.step_multiple({
   'i':   [0b11010, 0b00011, 0b01101]
}, {
    'out': [0b11, 0b01, 0b11]
})
```

The function now returns NamedTuples for usability, and something important to note is that the order of the fields returned is left-to-right based on the order in the original pattern string. Since the fields are returned in a NamedTuple, they can also be accessed by their field name, e.g.
```python
import pyrtl

i = pyrtl.Input(5, 'i')
out = pyrtl.Output(2, 'out')

with pyrtl.conditional_assignment:
    with pyrtl.match_bitpattern(i, '1a?a0') as x:
        out |= x.a
    with pyrtl.match_bitpattern(i, 'b0?1b') as x:
        out |= x.b
    with pyrtl.match_bitpattern(i, 'ba1ab') as x:
        out |= x.a + x.b

sim = pyrtl.Simulation()
sim.step_multiple({
   'i':   [0b11010, 0b00011, 0b01101]
}, {
    'out': [0b11, 0b01, 0b11]
})
```