### PR TITLE
Add option to emit 1-bit io after synthesis, and track io_map in PostSynth block.

### DIFF
--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -5,7 +5,6 @@ ways to change a block.
 """
 
 from __future__ import print_function, unicode_literals
-from re import I
 
 from .core import working_block, set_working_block, _get_debug_mode, LogicNet, PostSynthBlock
 from .helperfuncs import _NetCount

--- a/pyrtl/transform.py
+++ b/pyrtl/transform.py
@@ -194,6 +194,7 @@ def copy_block(block=None, update_working_block=True):
     for net in block_in.logic:
         _copy_net(block_out, net, temp_wv_map, mems)
     block_out.mem_map = mems
+    block_out.io_map = {io: w for io, w in temp_wv_map.items() if isinstance(io, (Input, Output))}
 
     if update_working_block:
         set_working_block(block_out)

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, unicode_literals, absolute_import
 
 import unittest
-from unittest.main import main
 import six
 import operator
 import os


### PR DESCRIPTION
When calling `pyrtl.synthesize()`, it previously always merged the IO wirevectors by inserting a series of slice nets to disassemble each input, and a single concat net to assemble each output. I think it's beneficial to have the option to *not* merge these IO vectors (for example, when emitting BLIF, you want the 1-bit IO).

This change adds the option to leave them unmerged by adding another argument to `pyrtl.synthesize()` (`merge_io_vectors=True`), defaulting to merging them like normal.

It also adds the information about the mapped IO, in either case, to the PostSynth block's `io_map`, which wasn't being used beforehand (but seems to have been initially added for this exact purpose).