### PR TITLE
Fix post-synth passes test; add reg_map for tracking registers post-synthesis

### DIFF
--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -730,11 +730,21 @@ class Block(object):
 class PostSynthBlock(Block):
     """ This is a block with extra metadata required to maintain the
     pre-synthesis interface during post-synthesis.
+
+    It currently holds the following instance attributes:
+
+    * *.io_map*: a map from old IO wirevector to a list of new IO wirevectors it maps to;
+        this is a list because for unmerged io vectors, each old N-bit IO wirevector maps
+        to N new 1-bit IO wirevectors.
+    * *.reg_map*: a map from old register to a list of new registers; a list because post-synthesis,
+        each N-bit register has been mapped to N 1-bit registers
+    * *.mem_map*: a map from old memory block to the new memory block
     """
 
     def __init__(self):
         super(PostSynthBlock, self).__init__()
-        self.io_map = {}
+        self.io_map = collections.defaultdict(list)
+        self.reg_map = collections.defaultdict(list)
         self.mem_map = {}
 
 

--- a/pyrtl/transform.py
+++ b/pyrtl/transform.py
@@ -195,6 +195,7 @@ def copy_block(block=None, update_working_block=True):
         _copy_net(block_out, net, temp_wv_map, mems)
     block_out.mem_map = mems
     block_out.io_map = {io: w for io, w in temp_wv_map.items() if isinstance(io, (Input, Output))}
+    block_out.reg_map = {r: w for r, w, in temp_wv_map.items() if isinstance(r, Register)}
 
     if update_working_block:
         set_working_block(block_out)


### PR DESCRIPTION
This PR fixes a test I had added in #343 (checking for correctness of io mapping in PostSynth blocks), and now also tracks registers in a separate `reg_map`.