### PR TITLE
Remove `replace_wire`, use `replace_wire_fast` instead; add tests and more documentation

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -110,4 +110,9 @@ from .passes import optimize
 from .passes import one_bit_selects
 from .passes import two_way_concat
 
-from .transform import net_transform, wire_transform, replace_wire, copy_block, clone_wire
+from .transform import net_transform
+from .transform import wire_transform
+from .transform import copy_block
+from .transform import clone_wire
+from .transform import replace_wires
+from .transform import replace_wire_fast

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -73,6 +73,56 @@ class TestWireTransform(NetWireNumTestCases):
             self.assertIsNot(arg, b)
         self.assertIsNot(new_and_net.dests[0], o)
 
+    def test_replace_input(self):
+
+        def f(wire):
+            if wire.name == 'a':
+                w = pyrtl.clone_wire(wire, 'w2')
+            else:
+                w = pyrtl.clone_wire(wire, 'w3')
+            return wire, w
+
+        a, b = pyrtl.input_list('a/1 b/1')
+        w1 = a & b
+        o = pyrtl.Output(1, 'o')
+        o <<= w1
+
+        src_nets, dst_nets = pyrtl.working_block().net_connections()
+        self.assertEqual(src_nets[w1], pyrtl.LogicNet('&', None, (a, b), (w1,)))
+        self.assertIn(a, dst_nets)
+        self.assertIn(b, dst_nets)
+
+        transform.wire_transform(f, select_types=pyrtl.Input, exclude_types=tuple())
+
+        w2 = pyrtl.working_block().get_wirevector_by_name('w2')
+        w3 = pyrtl.working_block().get_wirevector_by_name('w3')
+        src_nets, dst_nets = pyrtl.working_block().net_connections()
+        self.assertEqual(src_nets[w1], pyrtl.LogicNet('&', None, (w2, w3), (w1,)))
+        self.assertNotIn(a, dst_nets)
+        self.assertNotIn(b, dst_nets)
+
+    def test_replace_output(self):
+
+        def f(wire):
+            w = pyrtl.clone_wire(wire, 'w2')
+            return w, wire
+
+        a, b = pyrtl.input_list('a/1 b/1')
+        w1 = a & b
+        o = pyrtl.Output(1, 'o')
+        o <<= w1
+
+        src_nets, dst_nets = pyrtl.working_block().net_connections()
+        self.assertEqual(dst_nets[w1], [pyrtl.LogicNet('w', None, (w1,), (o,))])
+        self.assertIn(o, src_nets)
+
+        transform.wire_transform(f, select_types=pyrtl.Output, exclude_types=tuple())
+
+        w2 = pyrtl.working_block().get_wirevector_by_name('w2')
+        src_nets, dst_nets = pyrtl.working_block().net_connections()
+        self.assertEqual(dst_nets[w1], [pyrtl.LogicNet('w', None, (w1,), (w2,))])
+        self.assertNotIn(o, src_nets)
+
 
 class TestCopyBlock(NetWireNumTestCases, WireMemoryNameTestCases):
     def num_memories(self, mems_expected, block):


### PR DESCRIPTION
`replace_wire` is incorrect, I believe. In [line 101](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:transform-cleanup?expand=1#diff-67c9ebb170eeb38059bfed23e32ad4d0f03cba3f757e8f2085c6e768ece6302fL101), it uses `new_src` when it should be using `new_dst`. In addition, iterating over `block.logic` in lines [85](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:transform-cleanup?expand=1#diff-67c9ebb170eeb38059bfed23e32ad4d0f03cba3f757e8f2085c6e768ece6302fL85) and [96](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:transform-cleanup?expand=1#diff-67c9ebb170eeb38059bfed23e32ad4d0f03cba3f757e8f2085c6e768ece6302fL96) causes alterations to `block.logic` in lines [92](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:transform-cleanup?expand=1#diff-67c9ebb170eeb38059bfed23e32ad4d0f03cba3f757e8f2085c6e768ece6302fL92) and [103](https://github.com/UCSBarchlab/PyRTL/compare/development...pllab:transform-cleanup?expand=1#diff-67c9ebb170eeb38059bfed23e32ad4d0f03cba3f757e8f2085c6e768ece6302fL103), respectively, to cause a "Set changed size during iteration" error.

In addition, this was only used in `wire_transform`, which has a single unit test. I think we can instead just use and export `replace_wire_fast` and `replace_wires`, and use `replace_wire_fast` where `replace_wire` was used in `wire_transform`.