### PR TITLE
A different way of specifying conditional defaults

### DIFF
--- a/pyrtl/conditional.py
+++ b/pyrtl/conditional.py
@@ -34,7 +34,33 @@ This functionality is provided through two instances: "conditional_update", whic
 is a context manager (under which conditional assignements can be made), and "otherwise",
 which is an instance that stands in for a 'fall through' case.  The details of how these
 should be used, and the difference between normal assignments and condtional assignments,
-described in more detail in the state machine example from in prytl/examples.
+described in more detail in the state machine example in examples/example3-statemachine.py.
+
+There are instances where you might want a wirevector to be set to a certain value in all
+but certain with blocks. For example, say you have a processor with a PC register that is
+normally updated to PC + 1 after each cycle, except when the current instruction is
+a branch or jump. You could represent that as follows::
+
+    pc = pyrtl.Register(32)
+    instr = pyrtl.WireVector(32)
+    res = pyrtl.WireVector(32)
+
+    op = instr[:7]
+    ADD = 0b0110011
+    JMP = 0b1101111
+
+    with conditional_assignment(
+        defaults={
+            pc: pc + 1,
+            res: 0
+        }
+    ):
+        with op == ADD:
+            res |= instr[15:20] + instr[20:25]
+            # pc will be updated to pc + 1
+        with op == JMP:
+            pc.next |= pc + instr[7:]
+            # res will be set to 0
 
 In addition to the conditional context, there is a helper function "currently_under_condition"
 which will test if the code where it is called is currently elaborating hardware

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -133,7 +133,8 @@ class TestConditional(unittest.TestCase):
                 r1: r1 + 2,
                 r2: 6,
                 o: 3
-            }):
+            }
+        ):
             with i < 2:
                 r1.next |= r1 + 1
                 # r2 will be updated to 6

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -128,7 +128,12 @@ class TestConditional(unittest.TestCase):
         r2 = pyrtl.Register(bitwidth=3, name='r2')
         r3 = pyrtl.Register(bitwidth=3, name='r3')
         o = pyrtl.Output(bitwidth=3, name='o')
-        with pyrtl.conditional_assignment(defaults={r1: r1 + 2, r2: 6, o: 3}):
+        with pyrtl.conditional_assignment(
+            defaults={
+                r1: r1 + 2,
+                r2: 6,
+                o: 3
+            }):
             with i < 2:
                 r1.next |= r1 + 1
                 # r2 will be updated to 6


### PR DESCRIPTION
Registers can currently be given a special property, `condition_default`, which is used for updating the wire in the branch of conditional update if it's not updated otherwise.

This PR's approach is an alternative approach, by allowing the user to set to the default wire update values at the beginning of the conditional assignment block, like so:

```python
r1 = pyrtl.Register(bitwidth=3, name='r1')
r2 = pyrtl.Register(bitwidth=3, name='r2')
r3 = pyrtl.Register(bitwidth=3, name='r3')
o = pyrtl.Output(bitwidth=3, name='o')
with pyrtl.conditional_assignment(
    defaults={
       r1: r1 + 2,
       r2: 6,
       o: 3
    }):
    with i < 2:
        r1.next |= r1 + 1
        # r2 will be updated to 6
        # r3 remains the same as previous cycle
        o |= i
    with i < 3:
        # r1 will be updated to r1 + 2
        r2.next |= r2 + 1
        # r3 remains the same as previous cycle
        # o will be updated to 3
    with pyrtl.otherwise:
        # r1 will be updated to r1 + 2
        # r2 will be updated to 6
        r3.next |= 2
        o |= 7
```

Note that like before, it works for both registers and normal wirevectors.