### PR TITLE
Add ability to initialize registers and memories from trace when outputting Verilog testbench

### DIFF
--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -90,6 +90,11 @@ class CompiledSimulation(object):
         self._uid_counter = 0
         self.varname = {}  # mapping from wires and memories to C variables
 
+        # Passing the dictionary objects themselves since they aren't updated anywhere.
+        # If that's ever not the case, will need to pass in deep copies of them like done
+        # for the normal Simulation so we retain the initial values that had.
+        self.tracer._set_initial_values(default_value, register_value_map, memory_value_map)
+
         self._create_dll()
         self._initialize_mems()
 

--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -761,7 +761,8 @@ def output_verilog_testbench(dest_file, simulation_trace=None, toplevel_include=
               file=dest_file)
         for ix in range(max_iter):
             # Now just individually update the memory values that aren't the default
-            if (val := init_memvalue(m.id, ix)) is not None:
+            val = init_memvalue(m.id, ix)
+            if val is not None:
                 print('        block.mem_%s[%d] = %d;' % (m.id, ix, val), file=dest_file)
 
     if simulation_trace:

--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -646,13 +646,15 @@ def output_verilog_testbench(dest_file, simulation_trace=None, toplevel_include=
 
     :param dest_file: an open file to which the test bench will be printed.
     :param simulation_trace: a simulation trace from which the inputs will be extracted
-        for inclusion in the test bench.  The test bench generated will just replay the
-        inputs played to the simulation cycle by cycle.
+        for inclusion in the test bench. The test bench generated will just replay the
+        inputs played to the simulation cycle by cycle. The default values for all
+        registers and memories will be based on the trace, otherwise they will be initialized
+        to 0.
     :param toplevel_include: name of the file containing the toplevel module this testbench
-        is testing.  If not None, an `include` directive will be added to the top.
+        is testing. If not None, an `include` directive will be added to the top.
     :param vcd: By default the testbench generator will include a command in the testbench
         to write the output of the testbench execution to a .vcd file (via $dumpfile), and
-        this parameter is the string of the name of the file to use.  If None is specified
+        this parameter is the string of the name of the file to use. If None is specified
         instead, then no dumpfile will be used.
     :param cmd: The string passed as cmd will be copied verbatim into the testbench
         just before the end of each cycle. This is useful for doing things like printing
@@ -687,6 +689,26 @@ def output_verilog_testbench(dest_file, simulation_trace=None, toplevel_include=
 
     def name_list(wires):
         return [ver_name[w.name] for w in wires]
+
+    def init_regvalue(r):
+        if simulation_trace:
+            return simulation_trace.init_regvalue.get(r, simulation_trace.default_value)
+        else:
+            return 0
+
+    def init_memvalue(m, ix):
+        # Return None if not present, or if already equal to default value, so we know not to
+        # emit any additional Verilog initing this mem address.
+        if simulation_trace:
+            if m not in simulation_trace.init_memvalue:
+                return None
+            v = simulation_trace.init_memvalue[m].get(ix, simulation_trace.default_value)
+            return None if v == simulation_trace.default_value else v
+        else:
+            return None
+
+    def default_value():
+        return simulation_trace.default_value if simulation_trace else 0
 
     # Output an include, if given
     if toplevel_include:
@@ -731,11 +753,16 @@ def output_verilog_testbench(dest_file, simulation_trace=None, toplevel_include=
     # Initialize clk, and all the registers and memories
     print('        clk = 0;', file=dest_file)
     for r in name_sorted(registers):
-        print('        block.%s = 0;' % ver_name[r.name], file=dest_file)
+        print('        block.%s = %d;' % (ver_name[r.name], init_regvalue(r)), file=dest_file)
     for m in sorted(memories, key=lambda m: m.id):
+        max_iter = 1 << m.addrwidth
         print('        for (tb_iter = 0; tb_iter < %d; tb_iter++) '
-              'begin block.mem_%s[tb_iter] = 0; end' %
-              (1 << m.addrwidth, m.id), file=dest_file)
+              'begin block.mem_%s[tb_iter] = %d; end' % (max_iter, m.id, default_value()),
+              file=dest_file)
+        for ix in range(max_iter):
+            # Now just individually update the memory values that aren't the default
+            if (val := init_memvalue(m.id, ix)) is not None:
+                print('        block.mem_%s[%d] = %d;' % (m.id, ix, val), file=dest_file)
 
     if simulation_trace:
         tracelen = max(len(t) for t in simulation_trace.trace.values())

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -6,6 +6,7 @@ import sys
 import re
 import numbers
 import collections
+import copy
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import working_block, PostSynthBlock, _PythonSanitizer
@@ -93,7 +94,7 @@ class Simulation(object):
         self.tracer = tracer
         self._initialize(register_value_map, memory_value_map)
 
-    def _initialize(self, register_value_map=None, memory_value_map=None, default_value=None):
+    def _initialize(self, register_value_map=None, memory_value_map=None):
         """ Sets the wire, register, and memory values to default or as specified.
 
         :param register_value_map: is a map of {Register: value}.
@@ -102,15 +103,11 @@ class Simulation(object):
             default to. If no default_value is specified, it will use the value stored in the
             object (default to 0)
         """
-
-        if default_value is None:
-            default_value = self.default_value
-
         # set registers to their values
         reg_set = self.block.wirevector_subset(Register)
         if register_value_map is not None:
             for r in reg_set:
-                self.value[r] = self.regvalue[r] = register_value_map.get(r, default_value)
+                self.value[r] = self.regvalue[r] = register_value_map.get(r, self.default_value)
 
         # set constants to their set values
         for w in self.block.wirevector_subset(Const):
@@ -118,7 +115,6 @@ class Simulation(object):
             assert isinstance(w.val, numbers.Integral)  # for now
 
         # set memories to their passed values
-
         for mem_net in self.block.logic_subset('m@'):
             memid = mem_net.op_param[1].id
             if memid not in self.memvalue:
@@ -143,11 +139,14 @@ class Simulation(object):
         # set all other variables to default value
         for w in self.block.wirevector_set:
             if w not in self.value:
-                self.value[w] = default_value
+                self.value[w] = self.default_value
 
         self.ordered_nets = tuple((i for i in self.block))
         self.reg_update_nets = tuple((self.block.logic_subset('r')))
         self.mem_update_nets = tuple((self.block.logic_subset('@')))
+
+        self.tracer._set_initial_values(self.default_value, self.regvalue.copy(),
+                                        copy.deepcopy(self.memvalue))
 
     def step(self, provided_inputs):
         """ Take the simulation forward one cycle.
@@ -470,9 +469,7 @@ class FastSimulation(object):
         self.internal_names = _PythonSanitizer('_fastsim_tmp_')
         self._initialize(register_value_map, memory_value_map)
 
-    def _initialize(self, register_value_map=None, memory_value_map=None, default_value=None):
-        if default_value is None:
-            default_value = self.default_value
+    def _initialize(self, register_value_map=None, memory_value_map=None):
         if register_value_map is None:
             register_value_map = {}
 
@@ -482,10 +479,7 @@ class FastSimulation(object):
         # set registers to their values
         reg_set = self.block.wirevector_subset(Register)
         for r in reg_set:
-            if r in register_value_map:
-                self.regs[r.name] = register_value_map[r]
-            else:
-                self.regs[r.name] = default_value
+            self.regs[r.name] = register_value_map.get(r, self.default_value)
 
         self._initialize_mems(memory_value_map)
 
@@ -493,6 +487,9 @@ class FastSimulation(object):
         if self.code_file is not None:
             with open(self.code_file, 'w') as file:
                 file.write(s)
+
+        self.tracer._set_initial_values(self.default_value, self.regs.copy(),
+                                        copy.deepcopy(self.mems))
 
         context = {}
         logic_creator = compile(s, '<string>', 'exec')
@@ -504,7 +501,8 @@ class FastSimulation(object):
             for (mem, mem_map) in memory_value_map.items():
                 if isinstance(mem, RomBlock):
                     raise PyrtlError('error, one or more of the memories in the map is a RomBlock')
-                self.mems[self._mem_varname(mem)] = mem_map
+                name = self._mem_varname(mem)
+                self.mems[name] = mem_map
 
         for net in self.block.logic_subset('m@'):
             mem = net.op_param[1]
@@ -1008,6 +1006,10 @@ class SimulationTrace(object):
         self.wires_to_track = wires_to_track
         self.trace = TraceStorage(wires_to_track)
         self._wires = {wv.name: wv for wv in wires_to_track}
+        # remember for initializing during Verilog testbench output
+        self.default_value = 0
+        self.init_regvalue = {}
+        self.init_memvalue = {}
 
     def __len__(self):
         """ Return the current length of the trace in cycles. """
@@ -1219,3 +1221,18 @@ class SimulationTrace(object):
             print(formatted_trace_line(w, self.trace[w]), file=file)
         if extra_line:
             print(file=file)
+
+    def _set_initial_values(self, default_value, init_regvalue, init_memvalue):
+        """ Remember the default values that were used when starting the trace.
+
+        :param default_value: Default value to be used for all registers and
+            memory locations if not found in the other passed in maps
+        :param init_regvalue: Default value for registers
+        :param init_memvvalue: Default value for memory locations of given maps
+
+        This is needed when using this trace for outputting a Verilog testbench,
+        and is automatically called during simulation.
+        """
+        self.default_value = default_value
+        self.init_regvalue = init_regvalue
+        self.init_memvalue = init_memvalue

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -1228,9 +1228,12 @@ module tb();
         $dumpvars;
 
         clk = 0;
-        block.r1 = 0;
-        block.r2 = 0;
+        block.r1 = 2;
+        block.r2 = 3;
         block.tmp13 = 0;
+        for (tb_iter = 0; tb_iter < 32; tb_iter++) begin block.mem_0[tb_iter] = 0; end
+        block.mem_0[2] = 9;
+        block.mem_0[9] = 12;
         a100 = 2'd0;
         w1 = 4'd0;
         w12 = 3'd0;
@@ -1376,14 +1379,24 @@ class TestOutputTestbench(unittest.TestCase):
         i1, i2, i3 = pyrtl.input_list('w1/4 w12/3 a100/2')
         r1, r2 = pyrtl.register_list('r1/3 r2/4')
         r3 = pyrtl.Register(8)
+        mem = pyrtl.MemBlock(4, 5)
         o1, o2 = pyrtl.output_list('out1/2 out10/9')
         r1.next <<= i1 + i2
         r2.next <<= r1 * i3
         r3.next <<= r1 & r2
+        mem[i1] <<= r1 + 3
         o1 <<= i3 - r2
         o2 <<= r1
         sim_trace = pyrtl.SimulationTrace()
-        sim = pyrtl.Simulation(tracer=sim_trace)
+        sim = pyrtl.Simulation(tracer=sim_trace, register_value_map={
+            r1: 2,
+            r2: 3,
+        }, memory_value_map={
+            mem: {
+                2: 9,
+                9: 12,
+            },
+        })
         sim.step_multiple({
             'w1': [0, 4, 2, 3],
             'w12': [0, 1, 7, 4],


### PR DESCRIPTION
Currently, the testbench produced by `output_verilog_testbench()` sets all registers and memory locations to 0, rather than the values they were initialized to when given a trace.

# Before

For example:
```python
import pyrtl

i = pyrtl.Input(2, 'i')
r1 = pyrtl.Register(4, 'r1')
r2 = pyrtl.Register(5)
r3 = pyrtl.Register(2)
m = pyrtl.MemBlock(4, 5)
r2.next <<= r1 + m[4]
m[4] <<= r3 * i
r1.next <<= m[3] + r3
r3.next <<= r1 - 1

sim = pyrtl.Simulation(register_value_map={
    r1: 2,
    r2: 7,
}, memory_value_map={
    m: {
        4: 11,
        3: 7
    }
})

sim.step_multiple({
    'i': [0, 1, 2, 0, 2]  
}, nsteps=5)
sim.tracer.render_trace()
with open("tb.v", "w") as f:
    pyrtl.output_verilog_testbench(f, sim.tracer)
```

produces the following testbench code:
```verilog
module tb();
    reg clk;
    reg[1:0] i;

    integer tb_iter;
    toplevel block(.clk(clk), .i(i));

    always
        #5 clk = ~clk;

    initial begin
        $dumpfile ("waveform.vcd");
        $dumpvars;

        clk = 0;
        block.r1 = 0;
        block.tmp0 = 0;
        block.tmp1 = 0;
        for (tb_iter = 0; tb_iter < 32; tb_iter++) begin block.mem_0[tb_iter] = 0; end
        i = 2'd0;

        #10
        i = 2'd1;

        #10
        i = 2'd2;

        #10
        i = 2'd0;

        #10
        i = 2'd2;

        #10
        $finish;
    end
endmodule
```

# After

It now produces:
```verilog
module tb();
    reg clk;
    reg[1:0] i;

    integer tb_iter;
    toplevel block(.clk(clk), .i(i));

    always
        #5 clk = ~clk;

    initial begin
        $dumpfile ("waveform.vcd");
        $dumpvars;

        clk = 0;
        block.r1 = 2;
        block.tmp0 = 7;
        block.tmp1 = 0;
        for (tb_iter = 0; tb_iter < 32; tb_iter++) begin block.mem_0[tb_iter] = 0; end
        block.mem_0[3] = 7;
        block.mem_0[4] = 11;
        i = 2'd0;

        #10
        i = 2'd1;

        #10
        i = 2'd2;

        #10
        i = 2'd0;

        #10
        i = 2'd2;

        #10
        $finish;
    end
endmodule
```

Notably, the Python trace:
<img width="443" alt="Screen Shot 2021-04-30 at 7 28 11 PM" src="https://user-images.githubusercontent.com/2482771/116768303-724ca880-a9ea-11eb-9d26-625c6e697f0b.png">

didn't match the vcd before:
<img width="1007" alt="Screen Shot 2021-04-30 at 7 29 04 PM" src="https://user-images.githubusercontent.com/2482771/116768333-a0ca8380-a9ea-11eb-9de5-bffcdf2db4c0.png">

but now does:
<img width="1058" alt="Screen Shot 2021-04-30 at 7 26 56 PM" src="https://user-images.githubusercontent.com/2482771/116768326-98724880-a9ea-11eb-97d9-8710154f5382.png">
