### PR TITLE
Allow integer shift amounts for shifter corecircuits

### DIFF
--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -253,7 +253,7 @@ def shift_left_arithmetic(bits_to_shift, shift_amount):
     """ Shift left arithmetic operation.
 
     :param bits_to_shift: WireVector to shift left
-    :param shift_amount: WireVector specifying amount to shift
+    :param shift_amount: WireVector or integer specifying amount to shift
     :return: WireVector of same length as bits_to_shift
 
     This function returns a new WireVector of length equal to the length
@@ -270,7 +270,7 @@ def shift_right_arithmetic(bits_to_shift, shift_amount):
     """ Shift right arithmetic operation.
 
     :param bits_to_shift: WireVector to shift right
-    :param shift_amount: WireVector specifying amount to shift
+    :param shift_amount: WireVector or integer specifying amount to shift
     :return: WireVector of same length as bits_to_shift
 
     This function returns a new WireVector of length equal to the length
@@ -280,7 +280,9 @@ def shift_right_arithmetic(bits_to_shift, shift_amount):
     `bits_to_shift`) is shifted in. Note that `shift_amount` is treated as
     unsigned.
     """
-    a, shamt = _check_shift_inputs(bits_to_shift, shift_amount)
+    if isinstance(shift_amount, int):
+        return bits_to_shift[shift_amount:].sign_extended(len(bits_to_shift))
+
     bit_in = bits_to_shift[-1]  # shift in sign_bit
     dir = Const(0)  # shift right
     return barrel.barrel_shifter(bits_to_shift, bit_in, dir, shift_amount)
@@ -290,7 +292,7 @@ def shift_left_logical(bits_to_shift, shift_amount):
     """ Shift left logical operation.
 
     :param bits_to_shift: WireVector to shift left
-    :param shift_amount: WireVector specifying amount to shift
+    :param shift_amount: WireVector or integer specifying amount to shift
     :return: WireVector of same length as bits_to_shift
 
     This function returns a new WireVector of length equal to the length
@@ -299,7 +301,9 @@ def shift_left_logical(bits_to_shift, shift_amount):
     as unsigned number, meaning the zeroes are shifted in.  Note that
     `shift_amount` is treated as unsigned.
     """
-    a, shamt = _check_shift_inputs(bits_to_shift, shift_amount)
+    if isinstance(shift_amount, int):
+        return concat(bits_to_shift[:-shift_amount], Const(0, shift_amount))
+
     bit_in = Const(0)  # shift in a 0
     dir = Const(1)  # shift left
     return barrel.barrel_shifter(bits_to_shift, bit_in, dir, shift_amount)
@@ -309,7 +313,7 @@ def shift_right_logical(bits_to_shift, shift_amount):
     """ Shift right logical operation.
 
     :param bits_to_shift: WireVector to shift left
-    :param shift_amount: WireVector specifying amount to shift
+    :param shift_amount: WireVector or integer specifying amount to shift
     :return: WireVector of same length as bits_to_shift
 
     This function returns a new WireVector of length equal to the length
@@ -318,7 +322,9 @@ def shift_right_logical(bits_to_shift, shift_amount):
     as unsigned number, meaning the zeros are shifted in regardless of
     the "sign bit".  Note that `shift_amount` is treated as unsigned.
     """
-    a, shamt = _check_shift_inputs(bits_to_shift, shift_amount)
+    if isinstance(shift_amount, int):
+        return bits_to_shift[shift_amount:].zero_extended(len(bits_to_shift))
+
     bit_in = Const(0)  # shift in a 0
     dir = Const(0)  # shift right
     return barrel.barrel_shifter(bits_to_shift, bit_in, dir, shift_amount)

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -889,42 +889,52 @@ class TestShiftSimulation(unittest.TestCase):
         random.seed(8492049)
         pyrtl.reset_working_block()
 
-    def shift_checker(self, shift_func, ref_func, input_width, shift_width, test_amt=20):
+    def shift_checker(self, shift_func, ref_func, input_width, shift_width,
+                      shift_amount=None, test_amt=20):
+        inputs, all_inp_vals = [], []
         inp, inp_vals = utils.an_input_and_vals(input_width, test_vals=test_amt, name='inp')
-        shf, shf_vals = utils.an_input_and_vals(shift_width, test_vals=test_amt, name='shf')
+        inputs.append(inp)
+        all_inp_vals.append(inp_vals)
+        if shift_amount is not None:
+            shf, shf_vals = shift_amount, [shift_amount] * test_amt
+        else:
+            shf, shf_vals = utils.an_input_and_vals(shift_width, test_vals=test_amt, name='shf')
+            inputs.append(shf)
+            all_inp_vals.append(shf_vals)
         out = pyrtl.Output(input_width, "out")
         shf_out = shift_func(inp, shf)
         self.assertEqual(len(out), len(shf_out))  # output should have width of input
         out <<= shf_out
         true_result = [ref_func(i, s) for i, s in zip(inp_vals, shf_vals)]
-        shift_result = utils.sim_and_ret_out(out, [inp, shf], [inp_vals, shf_vals])
+        shift_result = utils.sim_and_ret_out(out, inputs, all_inp_vals)
         self.assertEqual(shift_result, true_result)
 
-    def sll_checker(self, input_width, shift_width):
+    def sll_checker(self, input_width, shift_width, shift_amount=None):
         mask = (1 << input_width) - 1
 
         def ref(i, s):
             return (i << s) & mask
 
-        self.shift_checker(pyrtl.shift_left_logical, ref, input_width, shift_width)
+        self.shift_checker(pyrtl.shift_left_logical, ref, input_width, shift_width, shift_amount)
 
-    def sla_checker(self, input_width, shift_width):
+    def sla_checker(self, input_width, shift_width, shift_amount=None):
         mask = (1 << input_width) - 1
 
         def ref(i, s):
             return (i << s) & mask
 
-        self.shift_checker(pyrtl.shift_left_arithmetic, ref, input_width, shift_width)
+        self.shift_checker(pyrtl.shift_left_arithmetic, ref, input_width,
+                           shift_width, shift_amount)
 
-    def srl_checker(self, input_width, shift_width):
+    def srl_checker(self, input_width, shift_width, shift_amount=None):
         mask = (1 << input_width) - 1
 
         def ref(i, s):
             return (i >> s) & mask
 
-        self.shift_checker(pyrtl.shift_right_logical, ref, input_width, shift_width)
+        self.shift_checker(pyrtl.shift_right_logical, ref, input_width, shift_width, shift_amount)
 
-    def sra_checker(self, input_width, shift_width):
+    def sra_checker(self, input_width, shift_width, shift_amount=None):
         # a little more work is required to take the positive number and treat it
         # as a twos complement number for the purpose of testing the shifter
         def ref(i, s):
@@ -933,7 +943,8 @@ class TestShiftSimulation(unittest.TestCase):
                 return ((~mask | i) >> s) & mask  # negative number
             else:
                 return (i >> s) & mask  # positive number
-        self.shift_checker(pyrtl.shift_right_arithmetic, ref, input_width, shift_width)
+        self.shift_checker(pyrtl.shift_right_arithmetic, ref, input_width,
+                           shift_width, shift_amount)
 
     def test_sll(self):
         self.sll_checker(5, 2)
@@ -970,6 +981,18 @@ class TestShiftSimulation(unittest.TestCase):
 
     def test_sra_over(self):
         self.sra_checker(4, 4)
+
+    def test_sll_integer_shift_amount(self):
+        self.sll_checker(5, 2, 1)
+
+    def test_sla_integer_shift_amount(self):
+        self.sla_checker(5, 2, 1)
+
+    def test_srl_integer_shift_amount(self):
+        self.srl_checker(5, 2, 1)
+
+    def test_sra_integer_shift_amount(self):
+        self.sra_checker(5, 2, 1)
 
 
 class TestBasicMult(unittest.TestCase):


### PR DESCRIPTION
Currently, shifting by an integer is not allowed in PyRTL. So instead of being able to do

```python
pyrtl.shift_left_logical(w, 2)
```

you currently have to do

```python
pyrtl.concat(w[:-2], pyrtl.Const(0, 2))
```

This PR allows shifting by an integer literal since the workaround is a little verbose/unintuitive.

Rather than causing a barrel shifter to be created in these cases, the PR uses an optimization that essentially checks for the integer literal cases, and in these cases, does a concatenation or slice as needed. Thus, the unoptimized netlist remains relatively clean.

For example, this given this code:
```python
i = pyrtl.Input(8, 'i')
o = pyrtl.Output(8, 'o')
o <<= pyrtl.shift_left_arithmetic(i, 2)  # or logical
```

using a barrel shifter would produce the following graphical output:

![shift_test_sla_barrel_shifter](https://user-images.githubusercontent.com/2482771/116987162-924ac900-ac83-11eb-9b1a-ea5eda6c3c3f.png)

while using this small optimization produces:

![shift_test_sla_new](https://user-images.githubusercontent.com/2482771/116987238-a8588980-ac83-11eb-8552-edc61e37d1b6.png)

They are logically the same, and when optimized synthesize down to the same size final netlist:

![shift_test_sla_new_synth_opt](https://user-images.githubusercontent.com/2482771/116987393-ddfd7280-ac83-11eb-8fc4-5003170b9629.png)
