### PR TITLE
Be able to show multiplicity of identical edges going to a net

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -127,6 +127,13 @@ class TestNetGraph(unittest.TestCase):
         # can be safely updated.
         self.assertEqual(len(g), 10)
 
+        self.assertEqual(len(g[inwire]), 1)
+        self.assertEqual(list(g[inwire].keys())[0].op, '|')
+        self.assertEqual(len(g[inwire].values()), 1)
+        edges = list(g[inwire].values())[0]
+        self.assertEqual(len(edges), 1)
+        self.assertIs(edges[0], inwire)
+
     def test_netgraph_unused_wires(self):
         genwire = pyrtl.WireVector(8, "genwire")
         inwire = pyrtl.Input(8, "inwire")
@@ -134,7 +141,17 @@ class TestNetGraph(unittest.TestCase):
         constwire = pyrtl.Const(8, 8)
         reg = pyrtl.Register(8, "reg")
         g = pyrtl.net_graph()
-        self.assertEquals(len(g), 0)
+        self.assertEqual(len(g), 0)
+
+    def test_netgraph_same_wire_multiple_edges_to_same_net(self):
+        c = pyrtl.Const(1, 1)
+        w = pyrtl.concat(c, c, c)
+        g = pyrtl.net_graph()
+        self.assertEqual(len(g[c]), 1)
+        edges = list(g[c].values())[0]
+        self.assertEqual(len(edges), 3)
+        for w in edges:
+            self.assertIs(w, c)
 
 
 class TestOutputIPynb(unittest.TestCase):


### PR DESCRIPTION
# Problem
When the same wire is the source to a particular net multiple times (e.g. a `c` net), `net_graph()`, and by extension all the graphical output functions that use it like `output_to_graphviz()`, don't properly display the additional edges.

For example, given:

```python
import pyrtl

c = pyrtl.Const(1, 1)
o = pyrtl.Output(3, 'o')
o <<= pyrtl.concat(c, c, c)
```

the logic of block is:
```python
for net in pyrtl.working_block():
    print(net)
```
```bash
tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C 
o/3O <-- w -- tmp0/3W 
```

however the result of `net_graph()` previously was:
```python
for src, vals in pyrtl.net_graph().items():
    for dst, edge in vals.items():
        print(f"({src}) - {edge} -> ({dst})"
```
```bash
(o/3O <-- w -- tmp0/3W ) - o/3O -> (o/3O)
(tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C ) - tmp0/3W -> (o/3O <-- w -- tmp0/3W )
(const_0_1/1C) - const_0_1/1C -> (tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C )
```

This problem is evident in the visual output as well:
![graph](https://user-images.githubusercontent.com/2482771/117040173-76184d80-acbe-11eb-95f4-b2b80f91febc.png)

# Solution
`net_graph` has been updated so that there are lists of edges between nodes.

```python
for src, vals in pyrtl.net_graph().items():
    for dst, edges in vals.items():
        for edge in edges:
            print(f"({src}) - {edge} -> ({dst})")
```
producing
```bash
(tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C ) - tmp0/3W -> (o/3O <-- w -- tmp0/3W )
(o/3O <-- w -- tmp0/3W ) - o/3O -> (o/3O)
(const_0_1/1C) - const_0_1/1C -> (tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C )
(const_0_1/1C) - const_0_1/1C -> (tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C )
(const_0_1/1C) - const_0_1/1C -> (tmp0/3W <-- c -- const_0_1/1C, const_0_1/1C, const_0_1/1C )
```
It now looks like:
![graph](https://user-images.githubusercontent.com/2482771/117040404-b37cdb00-acbe-11eb-91c5-6f7fb0d3420d.png)
