### PR TITLE
Add optional pass directly connecting nets to outputs when possible

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -107,6 +107,7 @@ from .passes import and_inverter_synth
 from .passes import optimize
 from .passes import one_bit_selects
 from .passes import two_way_concat
+from .passes import direct_connect_outputs
 
 from .transform import net_transform
 from .transform import wire_transform


### PR DESCRIPTION
While writing transforms for converting PyRTL into BLIF compatible with some superconducting design tools, I found it necessary to make sure that there were no wire nets in the netlist. Part of that process involved directly connecting outputs to their sources, bypassing any intermediate `w` nets if possible. This PR provides that pass, in case others find it useful.

Given
```python
i = pyrtl.Input(2, 'i')
j = pyrtl.Input(2, 'j')
o = pyrtl.Output(4, 'o')
o <<= i * j
```

# Before
![pre](https://user-images.githubusercontent.com/2482771/117083900-99f98480-acfa-11eb-9dfe-9964fe53f311.png)

# After
Call `pyrtl.direct_connect_outputs()` to produce

![post](https://user-images.githubusercontent.com/2482771/117083908-9d8d0b80-acfa-11eb-99f6-3a6f923e1cde.png)

The pass makes sure that it only does this when safe (e.g. maintaining the invariant that every net has a single destination wire), only doing that change when that destination wire only goes to a single destination `w` net which in turns goes to an Output.