### PR TITLE
Add optional pass for making all fanouts <= 2

### DIFF
--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -108,6 +108,7 @@ from .passes import optimize
 from .passes import one_bit_selects
 from .passes import two_way_concat
 from .passes import direct_connect_outputs
+from .passes import two_way_fanout
 
 from .transform import net_transform
 from .transform import wire_transform
@@ -122,3 +123,4 @@ from .analysis import TimingAnalysis
 from .analysis import yosys_area_delay
 from .analysis import paths
 from .analysis import distance
+from .analysis import fanout

--- a/pyrtl/analysis.py
+++ b/pyrtl/analysis.py
@@ -492,3 +492,17 @@ def distance(src, dst, f, block=None):
     # Turning path into tuple so it can be the key
     m = {tuple(path): sum(map(f, path)) for path in ps}
     return m
+
+
+def fanout(w):
+    """ Get the number of places a wire is used as an argument.
+
+    :param w: WireVector to check fanout for
+    :return: integer fanout count
+    """
+    _, dst_nets = w._block.net_connections()
+    if w not in dst_nets:
+        return 0
+
+    all_args = [arg for net in dst_nets[w] for arg in net.args]
+    return len(list(filter(lambda arg: arg is w, all_args)))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -246,5 +246,32 @@ class TestDistance(unittest.TestCase):
         self.assertEqual(list(distances.values())[0], 5)
 
 
+class TestFanout(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+
+    def test_fanout_simple(self):
+        i = pyrtl.Input(1, 'i')
+        o = pyrtl.Output(3, 'o')
+        w = i ^ 1
+        y = i | 1
+        z = i & 0
+        o <<= w + y + z
+        self.assertEqual(pyrtl.fanout(i), 3)
+        for wire in (w, y, z):
+            self.assertEqual(pyrtl.fanout(wire), 1)
+        self.assertEqual(pyrtl.fanout(o), 0)
+
+    def test_fanout_wire_repeated_as_arg(self):
+        i = pyrtl.Input(1, 'i')
+        _w = i * i
+        self.assertEqual(pyrtl.fanout(i), 2)
+
+    def test_fanout_wire_repeated_in_concat(self):
+        w = pyrtl.WireVector(2)
+        _c = pyrtl.concat(w, w, w, w)
+        self.assertEqual(pyrtl.fanout(w), 4)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -876,5 +876,49 @@ class TestDirectlyConnectedOutputs(unittest.TestCase):
         self.assertEqual(len(pyrtl.working_block().logic), 4)
 
 
+class TestTwoWayFanout(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+
+    def check_all_leq_two(self):
+        for w in pyrtl.working_block().wirevector_subset(exclude=(pyrtl.Output)):
+            self.assertLessEqual(pyrtl.fanout(w), 2)
+
+    def test_two_way_fanout_small_design(self):
+        i = pyrtl.Input(1, 'i')
+        o, p, q = pyrtl.output_list('o p q')
+        o <<= ~i
+        p <<= i
+        q <<= i & 0
+
+        self.assertEqual(pyrtl.fanout(i), 3)
+        pyrtl.two_way_fanout()
+        self.check_all_leq_two()
+
+    def test_two_way_fanout_medium_design(self):
+        i = pyrtl.Input(1, 'i')
+        o, p = pyrtl.output_list('o p')
+        w = i & 0
+        x = (w & w) ^ w
+        o <<= x
+        p <<= w
+
+        self.assertEqual(pyrtl.fanout(w), 4)
+        pyrtl.two_way_fanout()
+        self.check_all_leq_two()
+
+    def test_two_way_fanout_large_design(self):
+        i, j = pyrtl.input_list('i/1 j/2')
+        o, p, q, r = pyrtl.output_list('o p q r')
+        o <<= ~i
+        p <<= i * j
+        q <<= i & 0
+        r <<= i - 3
+
+        self.assertEqual(pyrtl.fanout(i), 4)
+        pyrtl.two_way_fanout()
+        self.check_all_leq_two()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds an optional pass (`pyrtl.two_way_fanout()`) that makes it so all wires go to at most 2 destinations. It also adds a convenient helper function called `pyrtl.fanout` for calculating the fanout of a wire.

In a future PR, it would be nice to make the maximum target fanout an argument to the function. Another nicety would be to optimize so that the first split after the original wire isn't needed.

Note the fanout of the wire coming out of `and` in this example was originally 4 but now has a tree of wires so that no fanout is greater than 2.

# Before
![pre](https://user-images.githubusercontent.com/2482771/117110743-73a80900-ad3b-11eb-911a-f4d3d6a80c3f.png)

# After
![post](https://user-images.githubusercontent.com/2482771/117110756-76a2f980-ad3b-11eb-9c91-1f38f0a67818.png)