### PR TITLE
Minor fix to replace_wires_fast

### DIFF
--- a/pyrtl/transform.py
+++ b/pyrtl/transform.py
@@ -183,7 +183,7 @@ def replace_wire_fast(orig_wire, new_src, new_dst, src_nets, dst_nets, block=Non
                 dst_nets[arg].append(net_)
         if len(net_.dests) == 1:
             src_nets[net_.dests[0]] = net_
-        block.add_net(new_net)
+        block.add_net(net_)
 
     # src and dst in this function are all relative to wires
     block = working_block(block)


### PR DESCRIPTION
An internal helper function within `replace_wires_fast` was using a variable declared outside of its immediate scope instead of the intended helper function argument. Since both variables aliased the same object, there was no functionality bug, but it's definitely possible that this might introduce a bug in the future if further changes are made. To make it clearer, this PR just changes the helper function to use the intended argument.

All tests still pass, and `replace_wires_fast` performs as intended.

E.g. in the following:
![t1](https://user-images.githubusercontent.com/2482771/117206726-10a08b80-ada8-11eb-971e-d07b73fd4a9a.png)

replacing `o` with `x` successfully produces:
![t2](https://user-images.githubusercontent.com/2482771/117206770-1a29f380-ada8-11eb-93c5-435b4c968efa.png)

(those object ids are just for visually verifying the third net object didn't change, but the first two did).