### PR TITLE
Add flatten() method to matrices

### DIFF
--- a/pyrtl/rtllib/matrix.py
+++ b/pyrtl/rtllib/matrix.py
@@ -665,6 +665,31 @@ class Matrix(object):
 
         raise PyrtlError('Power must be greater than or equal to 0')
 
+    def flatten(self, order='C'):
+        ''' Flatten the matrix into a single row.
+
+        :param str order: 'C' means row-major order (C-style), and
+            'F' means column-major order (Fortran-style).
+        :return: row vector matrix
+        '''
+        result = []
+        if order == 'C':
+            for r in range(self.rows):
+                for c in range(self.columns):
+                    result.append(as_wires(self[r, c], bitwidth=self.bits))
+        elif order == 'F':
+            for c in range(self.columns):
+                for r in range(self.rows):
+                    result.append(as_wires(self[r, c], bitwidth=self.bits))
+        else:
+            raise PyrtlError(
+                "Invalid order %s. Acceptable orders are 'C' (for row-major C-style order) "
+                "and 'F' (for column-major Fortran-style order)." % order
+            )
+
+        return Matrix(rows=1, columns=len(result), bits=self.bits,
+                      value=[result], max_bits=self.max_bits)
+
 
 def multiply(first, second):
     ''' Perform the elementwise or scalar multiplication operation.

--- a/tests/rtllib/test_matrix.py
+++ b/tests/rtllib/test_matrix.py
@@ -1454,6 +1454,31 @@ class TestMultiply(MatrixTestBase):
             result_matrix = Matrix.multiply(1, second_matrix)
 
 
+class TestFlatten(MatrixTestBase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+
+    def test_flatten_row_wise(self):
+        value = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        matrix = Matrix.Matrix(3, 3, 4, value=value)
+        flattened = matrix.flatten()
+        expected = [[0, 1, 2, 3, 4, 5, 6, 7, 8]]
+        self.check_against_expected(flattened, expected)
+
+    def test_flatten_column_wise(self):
+        value = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        matrix = Matrix.Matrix(3, 3, 4, value=value)
+        flattened = matrix.flatten(order='F')
+        expected = [[0, 3, 6, 1, 4, 7, 2, 5, 8]]
+        self.check_against_expected(flattened, expected)
+
+    def test_flatten_invalid_order(self):
+        with self.assertRaises(pyrtl.PyrtlError):
+            value = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+            matrix = Matrix.Matrix(3, 3, 4, value=value)
+            flattened = matrix.flatten(order='Z')
+
+
 class TestSum(MatrixTestBase):
     def setUp(self):
         pyrtl.reset_working_block()


### PR DESCRIPTION
This PR adds the `flatten()` method to the PyRTL matrix implementation. `flatten()` is also a method on numpy matrices, and our version supports two orders: row-wise and column-wise.