### PR TITLE
Minor fix to distance() analysis function

### DIFF
--- a/pyrtl/analysis.py
+++ b/pyrtl/analysis.py
@@ -414,7 +414,7 @@ def paths(src=None, dst=None, dst_nets=None, block=None):
         if None, will get paths from all Inputs
     :param WireVector dst: destination wire(s) to which to trace your paths
         if None, will get paths to all Outputs
-    :param {WireVector: {LogicNet}}: map from wire to set of nets where the
+    :param {WireVector: {LogicNet}} dst_nets: map from wire to set of nets where the
         wire is an argument; will compute it internally if not given via a
         call to pyrtl.net_connections()
     :param Block block: block to use (defaults to working block)
@@ -487,7 +487,7 @@ def distance(src, dst, f, block=None):
 
     This calls the given function f on each net in a path, summing the result.
     """
-    ps = paths(src, dst, block)
+    ps = paths(src, dst, block=block)
     ps = ps[src][dst]
     # Turning path into tuple so it can be the key
     m = {tuple(path): sum(map(f, path)) for path in ps}

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -206,13 +206,14 @@ class TestDistance(unittest.TestCase):
         pyrtl.reset_working_block()
 
     def test_simple_distance(self):
-        a = pyrtl.Input(4, 'a')
-        o = pyrtl.Output(name='o')
-        o <<= a * 2
+        for b in (None, pyrtl.working_block()):
+            a = pyrtl.Input(4, 'a')
+            o = pyrtl.Output(name='o')
+            o <<= a * 2
 
-        distances = pyrtl.distance(a, o, lambda _: 1)
-        self.assertEqual(len(distances), 1)
-        self.assertEqual(list(distances.values())[0], 2)
+            distances = pyrtl.distance(a, o, lambda _: 1, b)
+            self.assertEqual(len(distances), 1)
+            self.assertEqual(list(distances.values())[0], 2)
 
     def test_several_distances(self):
         a = pyrtl.Input(4, 'a')


### PR DESCRIPTION
This PR makes sure the proper argument is being passed to the `paths()` call for the keyword argument `block`.