### PR TITLE
Add graphviz as Binder (Jupyter) dependency

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+graphviz

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,3 @@
+set -e
+
+pip install graphviz


### PR DESCRIPTION
Since `requirements.txt` is limited solely to the packages that users need to run the normal parts of PyRTL, it does not contain the `graphviz` dependency. However, some of the Jupyter example files do require `graphviz`, and so we need a way to tell the binder to install these additional packages automatically.

Both `apt.txt` and `postBuild` are used soley by `mybinder.org` at the moment.