### PR TITLE
Fix bug when add_reset=False; add Register tests

### DIFF
--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -630,7 +630,10 @@ def _to_verilog_sequential(file, block, varname, add_reset):
                     rval = 0
                 print('            {:s} <= {:d};'.format(dest, rval), file=file)
         print('        end', file=file)
-    print('        else begin', file=file)
+        print('        else begin', file=file)
+    else:
+        print('        begin', file=file)
+
     for net in _net_sorted(block.logic, varname):
         if net.op == 'r':
             dest, src = (varname(net.dests[0]), varname(net.args[0]))

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -1271,7 +1271,7 @@ module toplevel(clk, o);
     // Registers
     always @(posedge clk)
     begin
-        else begin
+        begin
             tmp0 <= tmp4;
         end
     end

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -225,6 +225,29 @@ class TestRegister(unittest.TestCase):
         with self.assertRaises(pyrtl.PyrtlError):
             a = (self.r.next or True)
 
+    def test_reset_value_is_none(self):
+        self.assertIsNone(self.r.reset_value)
+
+    def test_reset_value_is_correct(self):
+        r = pyrtl.Register(4, reset_value=1)
+        self.assertEqual(r.reset_value, 1)
+
+    def test_reset_value_as_string(self):
+        r = pyrtl.Register(4, reset_value="2'd1")
+        self.assertEqual(r.reset_value, 1)
+
+    def test_invalid_reset_value_too_large(self):
+        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+            r = pyrtl.Register(4, reset_value=16)
+
+    def test_invalid_reset_value_too_large_as_string(self):
+        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+            r = pyrtl.Register(4, reset_value="5'd16")
+
+    def test_invalid_reset_value_not_an_integer(self):
+        with self.assertRaises(pyrtl.PyrtlError):
+            r = pyrtl.Register(4, reset_value='hello')
+
 
 # -------------------------------------------------------------------
 class TestConst(unittest.TestCase):


### PR DESCRIPTION
Fixes issue where extra `else` is inserted into Verilog when `add_reset=False`.

Also adds tests just related to setting the `reset_value` in the Register initializer.