### PR TITLE
Add ability to specify how values render in trace; improve symbol_len calculation.

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -876,15 +876,15 @@ class _WaveRendererBase(object):
         num_tick = self._tick + str(n)
         return num_tick.ljust(symbol_len * segment_size)
 
-    def render_val(self, w, n, current_val, symbol_len, repr_func):
+    def render_val(self, w, n, current_val, symbol_len, repr_func, repr_per_name):
         if w is not self.prev_wire:
             self.prev_wire = w
             self.prior_val = current_val
-        out = self._render_val_with_prev(w, n, current_val, symbol_len, repr_func)
+        out = self._render_val_with_prev(w, n, current_val, symbol_len, repr_func, repr_per_name)
         self.prior_val = current_val
         return out
 
-    def _render_val_with_prev(self, w, n, current_val, symbol_len, repr_func):
+    def _render_val_with_prev(self, w, n, current_val, symbol_len, repr_func, repr_per_name):
         """Return a string encoding the given value in a waveform.
 
         :param w: The WireVector we are rendering to a waveform
@@ -892,19 +892,30 @@ class _WaveRendererBase(object):
         :param current_val: the value to be rendered
         :param symbol_len: and integer for how big to draw the current value
         :param repr_func: function to use for representing the current_val;
-            examples are 'hex', 'oct', 'bin', and 'str' (for decimal). Defaults to 'hex'.
+            examples are 'hex', 'oct', 'bin', 'str' (for decimal), or even the name
+            of an IntEnum class you know the value will belong to. Defaults to 'hex'.
+        :param repr_per_name: Map from signal name to a function that takes in the signal's
+            value and returns a user-defined representation. If a signal name is
+            not found in the map, the argument `repr_func` will be used instead.
 
         Returns a string of printed length symbol_len that will draw the
         representation of current_val.  The input prior_val is used to
         render transitions.
         """
+        def to_str(v):
+            f = repr_per_name.get(w.name)
+            if f is None:
+                return str(repr_func(v))
+            else:
+                return str(f(v))
+
         sl = symbol_len - 1
         if len(w) > 1:
             out = self._revstart
             if current_val != self.prior_val:
-                out += self._x + repr_func(current_val).rstrip('L').ljust(sl)[:sl]
+                out += self._x + to_str(current_val).rstrip('L').ljust(sl)[:sl]
             elif n == 0:
-                out += repr_func(current_val).rstrip('L').ljust(symbol_len)[:symbol_len]
+                out += to_str(current_val).rstrip('L').ljust(symbol_len)[:symbol_len]
             else:
                 out += ' ' * symbol_len
             out += self._revstop
@@ -1132,7 +1143,8 @@ class SimulationTrace(object):
 
     def render_trace(
             self, trace_list=None, file=sys.stdout, render_cls=default_renderer(),
-            symbol_len=5, repr_func=hex, segment_size=5, segment_delim=' ', extra_line=True):
+            symbol_len=5, repr_func=hex, repr_per_name={}, segment_size=5,
+            segment_delim=' ', extra_line=True):
 
         """ Render the trace to a file using unicode and ASCII escape sequences.
 
@@ -1144,6 +1156,9 @@ class SimulationTrace(object):
             represented value fits.
         :param repr_func: Function to use for representing each value in the trace;
             examples are 'hex', 'oct', 'bin', and 'str' (for decimal). Defaults to 'hex'.
+        :param repr_per_name: Map from signal name to a function that takes in the signal's
+            value and returns a user-defined representation. If a signal name is
+            not found in the map, the argument `repr_func` will be used instead.
         :param segment_size: Traces are broken in the segments of this number of cycles.
         :param segment_delim: The character to be output between segments.
         :param extra_line: A Boolean to determine if we should print a blank line between signals.
@@ -1172,12 +1187,12 @@ class SimulationTrace(object):
         else:
             self.render_trace_to_text(
                 trace_list=trace_list, file=file, render_cls=render_cls,
-                symbol_len=symbol_len, repr_func=repr_func, segment_size=segment_size,
-                segment_delim=segment_delim, extra_line=extra_line)
+                symbol_len=symbol_len, repr_func=repr_func, repr_per_name=repr_per_name,
+                segment_size=segment_size, segment_delim=segment_delim, extra_line=extra_line)
 
     def render_trace_to_text(
             self, trace_list, file, render_cls,
-            symbol_len, repr_func, segment_size, segment_delim, extra_line):
+            symbol_len, repr_func, repr_per_name, segment_size, segment_delim, extra_line):
 
         renderer = render_cls()
 
@@ -1192,7 +1207,8 @@ class SimulationTrace(object):
                     i % segment_size,
                     trace[i],
                     symbol_len,
-                    repr_func)
+                    repr_func,
+                    repr_per_name)
             return heading + trace_line
 
         # default to printing all signals in sorted order
@@ -1212,9 +1228,17 @@ class SimulationTrace(object):
                 "if a CompiledSimulation was used.")
 
         if symbol_len is None:
+
+            def to_str(v, name):
+                f = repr_per_name.get(name)
+                if f is None:
+                    return str(repr_func(v))
+                else:
+                    return str(f(v))
+
             maxvallen = 0
-            for trace in self.trace.values():
-                maxvallen = max(maxvallen, max(len(repr_func(v)) for v in trace))
+            for name, trace in self.trace.items():
+                maxvallen = max(maxvallen, max(len(to_str(v, name)) for v in trace))
             symbol_len = maxvallen + 1
 
         # print the 'ruler' which is just a list of 'ticks'

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -481,14 +481,15 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None, repr_func=hex):
 
     wave_template = (
         """\
-        <script type="WaveDrom">
-        { signal : [
-        %s
-        ],
-        config: {hscale: %d }}
-        </script>
-
-        """
+<script type="WaveDrom">
+{
+  signal : [
+%s
+  ],
+  config: { hscale: %d }
+}
+</script>
+"""
     )
 
     vallens = []  # For determining longest value length
@@ -501,7 +502,7 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None, repr_func=hex):
             if last == value:
                 wavelist.append('.')
             else:
-                if len(w) == 1:
+                if len(simtrace._wires[w]) == 1:
                     wavelist.append(str(value))
                 else:
                     wavelist.append('=')
@@ -510,14 +511,15 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None, repr_func=hex):
 
         wavestring = ''.join(wavelist)
         datastring = ', '.join(['"%s"' % repr_func(data) for data in datalist])
-        vallens.extend([len(repr_func(data)) for data in datalist])
-        if len(w) == 1:
+        if len(simtrace._wires[w]) == 1:
+            vallens.append(1)  # all are the same length
             return bool_signal_template % (w, wavestring)
         else:
+            vallens.extend([len(repr_func(data)) for data in datalist])
             return int_signal_template % (w, wavestring, datastring)
 
-    bool_signal_template = '{ name: "%s",  wave: "%s" },'
-    int_signal_template = '{ name: "%s",  wave: "%s", data: [%s] },'
+    bool_signal_template = '    { name: "%s",  wave: "%s" },'
+    int_signal_template = '    { name: "%s",  wave: "%s", data: [%s] },'
     signals = [extract(w) for w in trace_list]
     all_signals = '\n'.join(signals)
     maxvallen = max(vallens)

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -459,7 +459,7 @@ def block_to_svg(block=None, split_state=True, maintain_arg_order=False):
 #    |__|  |  |\/| |
 #    |  |  |  |  | |___
 
-def trace_to_html(simtrace, trace_list=None, sortkey=None):
+def trace_to_html(simtrace, trace_list=None, sortkey=None, repr_func=hex):
     """ Return a HTML block showing the trace.
 
     :param simtrace: A SimulationTrace object
@@ -484,11 +484,14 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None):
         <script type="WaveDrom">
         { signal : [
         %s
-        ]}
+        ],
+        config: {hscale: %d }}
         </script>
 
         """
     )
+
+    vallens = []  # For determining longest value length
 
     def extract(w):
         wavelist = []
@@ -506,7 +509,8 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None):
                 last = value
 
         wavestring = ''.join(wavelist)
-        datastring = ', '.join(['"%d"' % data for data in datalist])
+        datastring = ', '.join(['"%s"' % repr_func(data) for data in datalist])
+        vallens.extend([len(repr_func(data)) for data in datalist])
         if len(w) == 1:
             return bool_signal_template % (w, wavestring)
         else:
@@ -516,6 +520,8 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None):
     int_signal_template = '{ name: "%s",  wave: "%s", data: [%s] },'
     signals = [extract(w) for w in trace_list]
     all_signals = '\n'.join(signals)
-    wave = wave_template % all_signals
+    maxvallen = max(vallens)
+    scale = (maxvallen // 5) + 1
+    wave = wave_template % (all_signals, scale)
     # print(wave)
     return wave

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -382,26 +382,50 @@ class TestOutputIPynb(unittest.TestCase):
         )
         self.assertEqual(htmlstring, expected)
 
-    def test_trace_to_html_repr_func_2(self):
-        i = pyrtl.Input(1, 'i')
-        o = pyrtl.Output(2, 'o')
-        o <<= i + 1
+    def test_trace_to_html_repr_per_name(self):
+        from enum import IntEnum
+
+        class Foo(IntEnum):
+            A = 0
+            B = 1
+            C = 2
+            D = 3
+
+        i = pyrtl.Input(4, 'i')
+        state = pyrtl.Register(max(Foo).bit_length(), name='state')
+        o = pyrtl.Output(name='o')
+        o <<= state
+
+        with pyrtl.conditional_assignment:
+            with i == 0b0001:
+                state.next |= Foo.A
+            with i == 0b0010:
+                state.next |= Foo.B
+            with i == 0b0100:
+                state.next |= Foo.C
+            with i == 0b1000:
+                state.next |= Foo.D
 
         sim = pyrtl.Simulation()
-        sim.step_multiple({'i': '0100110'})
-        htmlstring = pyrtl.trace_to_html(sim.tracer, repr_func=bin)
+        sim.step_multiple({
+            'i': [1, 2, 4, 8, 0]
+        })
+
+        htmlstring = pyrtl.trace_to_html(sim.tracer, repr_per_name={'state': Foo})
         expected = (
             '<script type="WaveDrom">\n'
             '{\n'
             '  signal : [\n'
-            '    { name: "i",  wave: "010.1.0" },\n'
-            '    { name: "o",  wave: "===.=.=", data: ["0b1", "0b10", "0b1", "0b10", "0b1"] },\n'
+            '    { name: "i",  wave: "=====", data: ["0x1", "0x2", "0x4", "0x8", "0x0"] },\n'
+            '    { name: "o",  wave: "=.===", data: ["0x0", "0x1", "0x2", "0x3"] },\n'
+            '    { name: "state",  wave: "=.===", data: ["Foo.A", "Foo.B", "Foo.C", "Foo.D"] },\n'
             '  ],\n'
-            '  config: { hscale: 1 }\n'
+            '  config: { hscale: 2 }\n'
             '}\n'
             '</script>\n'
         )
         self.assertEqual(htmlstring, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -340,6 +340,68 @@ class TestOutputIPynb(unittest.TestCase):
 
         htmlstring = pyrtl.trace_to_html(sim_trace)  # tests if it compiles or not
 
+    def test_trace_to_html(self):
+        i = pyrtl.Input(1, 'i')
+        o = pyrtl.Output(2, 'o')
+        o <<= i + 1
+
+        sim = pyrtl.Simulation()
+        sim.step_multiple({'i': '0100110'})
+        htmlstring = pyrtl.trace_to_html(sim.tracer)
+        expected = (
+            '<script type="WaveDrom">\n'
+            '{\n'
+            '  signal : [\n'
+            '    { name: "i",  wave: "010.1.0" },\n'
+            '    { name: "o",  wave: "===.=.=", data: ["0x1", "0x2", "0x1", "0x2", "0x1"] },\n'
+            '  ],\n'
+            '  config: { hscale: 1 }\n'
+            '}\n'
+            '</script>\n'
+        )
+        self.assertEqual(htmlstring, expected)
+
+    def test_trace_to_html_repr_func(self):
+        i = pyrtl.Input(1, 'i')
+        o = pyrtl.Output(2, 'o')
+        o <<= i + 1
+
+        sim = pyrtl.Simulation()
+        sim.step_multiple({'i': '0100110'})
+        htmlstring = pyrtl.trace_to_html(sim.tracer, repr_func=bin)
+        expected = (
+            '<script type="WaveDrom">\n'
+            '{\n'
+            '  signal : [\n'
+            '    { name: "i",  wave: "010.1.0" },\n'
+            '    { name: "o",  wave: "===.=.=", data: ["0b1", "0b10", "0b1", "0b10", "0b1"] },\n'
+            '  ],\n'
+            '  config: { hscale: 1 }\n'
+            '}\n'
+            '</script>\n'
+        )
+        self.assertEqual(htmlstring, expected)
+
+    def test_trace_to_html_repr_func_2(self):
+        i = pyrtl.Input(1, 'i')
+        o = pyrtl.Output(2, 'o')
+        o <<= i + 1
+
+        sim = pyrtl.Simulation()
+        sim.step_multiple({'i': '0100110'})
+        htmlstring = pyrtl.trace_to_html(sim.tracer, repr_func=bin)
+        expected = (
+            '<script type="WaveDrom">\n'
+            '{\n'
+            '  signal : [\n'
+            '    { name: "i",  wave: "010.1.0" },\n'
+            '    { name: "o",  wave: "===.=.=", data: ["0b1", "0b10", "0b1", "0b10", "0b1"] },\n'
+            '  ],\n'
+            '  config: { hscale: 1 }\n'
+            '}\n'
+            '</script>\n'
+        )
+        self.assertEqual(htmlstring, expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As I've been analyzing many traces, I've found it useful to be able to specify the format that the values are represented in the wave form. I.e. I'd like to be able to specify that the numbers should be represented as hexadecimal (the default), or binary, or octal, or decimal, or some other format. This PR makes it possible by passing in a representation function to `render_trace()`. This also adds more tests.

E.g. now we get (here is the same trace printed in binary, hex, oct, and decimal one after the other), via this code:
```python
sim.tracer.render_trace(repr_func=bin, symbol_len=None)
sim.tracer.render_trace(repr_func=hex, symbol_len=None)
sim.tracer.render_trace(repr_func=oct, symbol_len=None)
sim.tracer.render_trace(repr_func=str, symbol_len=None)
```

<img width="852" alt="Screen Shot 2021-06-15 at 11 28 08 AM" src="https://user-images.githubusercontent.com/2482771/122104667-c52cc480-cdcc-11eb-84ad-0d066525546f.png">

It also works for the `trace_to_html` (used by the IPython notebooks):

<img width="986" alt="Screen Shot 2021-06-15 at 4 16 32 AM" src="https://user-images.githubusercontent.com/2482771/122104526-99a9da00-cdcc-11eb-9c85-44160c4bd71f.png">

<img width="986" alt="Screen Shot 2021-06-15 at 4 16 49 AM" src="https://user-images.githubusercontent.com/2482771/122104518-97e01680-cdcc-11eb-8be3-fbd1488e530e.png">

<img width="986" alt="Screen Shot 2021-06-15 at 4 17 10 AM" src="https://user-images.githubusercontent.com/2482771/122104505-94e52600-cdcc-11eb-8371-3470233ac8cd.png">

<img width="986" alt="Screen Shot 2021-06-15 at 4 17 22 AM" src="https://user-images.githubusercontent.com/2482771/122104487-91ea3580-cdcc-11eb-8ef5-c22ddc17bb9f.png">

Also adds a `repr_per_name` function that allows you to specify a representation per wire, via a dictionary mapping a wire name to a function that produces a string. This way, you get things like:

<img width="481" alt="Screen Shot 2021-06-15 at 2 13 54 PM" src="https://user-images.githubusercontent.com/2482771/122124378-109e9d00-cde4-11eb-8930-2c8edfe1c7d5.png">

<img width="481" alt="Screen Shot 2021-06-15 at 2 13 39 PM" src="https://user-images.githubusercontent.com/2482771/122124395-16947e00-cde4-11eb-9f24-24729e6d90f5.png">

(ability to see the names of enums used).

