### PR TITLE
Fix html trace visualization when value is a boolean and/or supplied …

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -7,6 +7,7 @@ import re
 import numbers
 import collections
 import copy
+import six
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import working_block, PostSynthBlock, _PythonSanitizer
@@ -627,9 +628,18 @@ class FastSimulation(object):
                 "any expected outputs must have a supplied value "
                 "each step of simulation")
 
+        def to_num(v):
+            if isinstance(v, six.string_types):
+                # Don't use infer_val_and_bitwidth because they aren't in
+                # Verilog-style format, but are instead in plain decimal.
+                return int(v)
+            # Don't just call int(v) on all of them since it's nice
+            # to retain class info if they were a subclass of int.
+            return v
+
         failed = []
         for i in range(nsteps):
-            self.step({w: int(v[i]) for w, v in provided_inputs.items()})
+            self.step({w: to_num(v[i]) for w, v in provided_inputs.items()})
 
             for expvar in expected_outputs.keys():
                 expected = int(expected_outputs[expvar][i])

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -504,31 +504,31 @@ def trace_to_html(simtrace, trace_list=None, sortkey=None, repr_func=hex, repr_p
         wavelist = []
         datalist = []
         last = None
+
         for i, value in enumerate(trace[w]):
             if last == value:
                 wavelist.append('.')
             else:
-                if len(simtrace._wires[w]) == 1:
-                    wavelist.append(str(value))
+                f = repr_per_name.get(w)
+                if f is not None:
+                    wavelist.append('=')
+                    datalist.append(str(f(value)))
+                elif len(simtrace._wires[w]) == 1:
+                    # int() to convert True/False to 0/1
+                    wavelist.append(str(int(value)))
                 else:
                     wavelist.append('=')
-                    datalist.append((value, w))
+                    datalist.append(str(repr_func(value)))
+
                 last = value
 
-        def to_str(v, name):
-            f = repr_per_name.get(name)
-            if f is not None:
-                return str(f(v))
-            else:
-                return str(repr_func(v))
-
         wavestring = ''.join(wavelist)
-        datastring = ', '.join(['"%s"' % to_str(data, name) for data, name in datalist])
-        if len(simtrace._wires[w]) == 1:
+        datastring = ', '.join(['"%s"' % data for data in datalist])
+        if repr_per_name.get(w) is None and len(simtrace._wires[w]) == 1:
             vallens.append(1)  # all are the same length
             return bool_signal_template % (w, wavestring)
         else:
-            vallens.extend([len(to_str(data, name)) for data, name in datalist])
+            vallens.extend([len(data) for data in datalist])
             return int_signal_template % (w, wavestring, datastring)
 
     bool_signal_template = '    { name: "%s",  wave: "%s" },'


### PR DESCRIPTION
When the wire was 1-bit wide and the value provided was a boolean (True/False) rather than an int, the html trace visualization printed 'True'/'False' instead of '0'/'1'. This PR fixes that.

It also adds a small change to step_multiple() so that int subclasses aren't always cast to ints, thus preserving their subclass information (e.g. IntEnums). This may be helpful in the future for automatically detecting and displaying int subclasses specially in the trace (rather than needing to supply a map in `repr_per_name`).

Now:
<img width="1343" alt="Screen Shot 2021-06-16 at 6 58 18 PM" src="https://user-images.githubusercontent.com/2482771/122319006-d8c35280-ced4-11eb-8a3c-f9cce65b6558.png">
