### PR TITLE
Add ability to specify dont-cares in expected output of step_multiple

### DIFF
--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -137,7 +137,7 @@ class CompiledSimulation(object):
 
         :param provided_inputs: a dictionary mapping wirevectors to their values for N steps
         :param expected_outputs: a dictionary mapping wirevectors to their expected values
-            for N steps
+            for N steps; use '?' to indicate you don't care what the value at that step is
         :param nsteps: number of steps to take (defaults to None, meaning step for each
             supplied input value)
         :param file: where to write the output (if there are unexpected outputs detected)
@@ -214,7 +214,10 @@ class CompiledSimulation(object):
             self.step({w: int(v[i]) for w, v in provided_inputs.items()})
 
             for expvar in expected_outputs.keys():
-                expected = int(expected_outputs[expvar][i])
+                expected = expected_outputs[expvar][i]
+                if expected == '?':
+                    continue
+                expected = int(expected)
                 actual = self.inspect(expvar)
                 if expected != actual:
                     failed.append((i, expvar, expected, actual))

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -228,7 +228,7 @@ class Simulation(object):
 
         :param provided_inputs: a dictionary mapping wirevectors to their values for N steps
         :param expected_outputs: a dictionary mapping wirevectors to their expected values
-            for N steps
+            for N steps; use '?' to indicate you don't care what the value at that step is
         :param nsteps: number of steps to take (defaults to None, meaning step for each
             supplied input value)
         :param file: where to write the output (if there are unexpected outputs detected)
@@ -305,7 +305,10 @@ class Simulation(object):
             self.step({w: int(v[i]) for w, v in provided_inputs.items()})
 
             for expvar in expected_outputs.keys():
-                expected = int(expected_outputs[expvar][i])
+                expected = expected_outputs[expvar][i]
+                if expected == '?':
+                    continue
+                expected = int(expected)
                 actual = self.inspect(expvar)
                 if expected != actual:
                     failed.append((i, expvar, expected, actual))
@@ -556,7 +559,7 @@ class FastSimulation(object):
 
         :param provided_inputs: a dictionary mapping wirevectors to their values for N steps
         :param expected_outputs: a dictionary mapping wirevectors to their expected values
-            for N steps
+            for N steps; use '?' to indicate you don't care what the value at that step is
         :param nsteps: number of steps to take (defaults to None, meaning step for each
             supplied input value)
         :param file: where to write the output (if there are unexpected outputs detected)
@@ -642,7 +645,10 @@ class FastSimulation(object):
             self.step({w: to_num(v[i]) for w, v in provided_inputs.items()})
 
             for expvar in expected_outputs.keys():
-                expected = int(expected_outputs[expvar][i])
+                expected = expected_outputs[expvar][i]
+                if expected == '?':
+                    continue
+                expected = int(expected)
                 actual = self.inspect(expvar)
                 if expected != actual:
                     failed.append((i, expvar, expected, actual))

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -302,7 +302,7 @@ class SimStepMultipleBase(unittest.TestCase):
         out2 <<= in1 | in2
         self.inputs = {
             'in1': [0, 1, 3, 15, 14],
-            'in2': [6, 6, 6, 6, 6],
+            'in2': '66666',  # When a string, assumes each input is a single digit integer
         }
 
     def test_step_multiple_nsteps_no_inputs(self):
@@ -412,6 +412,25 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+    def test_step_multiple_dont_care_expected(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        expected = {
+            'out1': [7, '?', 6, 10],
+            'out2': '6?7?',
+        }
+        sim.step_multiple(self.inputs, expected, nsteps=4)
+
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1   0  1  3 15\n"
+                          "in2   6  6  6  6\n"
+                          "out1  7  8  6 10\n"
+                          "out2  6  7  7 15\n")
         output = six.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -547,7 +547,7 @@ class SimStepMultipleBase(unittest.TestCase):
         out2 <<= in1 | in2
         self.inputs = {
             'in1': [0, 1, 3, 15, 14],
-            'in2': [6, 6, 6, 6, 6],
+            'in2': '66666',  # When a string, assumes each input is a single digit integer
         }
 
     def test_step_multiple_nsteps_no_inputs(self):
@@ -659,6 +659,25 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
+        output = six.StringIO()
+        sim_trace.print_trace(output)
+        self.assertEqual(output.getvalue(), correct_output)
+
+    def test_step_multiple_dont_care_expected(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+
+        expected = {
+            'out1': [7, '?', 6, 10],
+            'out2': '6?7?',
+        }
+        sim.step_multiple(self.inputs, expected, nsteps=4)
+
+        correct_output = (" --- Values in base 10 ---\n"
+                          "in1   0  1  3 15\n"
+                          "in2   6  6  6  6\n"
+                          "out1  7  8  6 10\n"
+                          "out2  6  7  7 15\n")
         output = six.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)


### PR DESCRIPTION
There have been instances when I'd like to use the `expected_outputs` feature of `step_multiple`, but only care about the value of a wire on a certain clock cycle (e.g. when dealing with protocols, or output wires that change and whose values don't matter until a finished signal is high). This PR allows you to specify don't-cares in expected outputs via `?`. This doesn't change how we specify input values, which still require numeric values for every input for every step.