### PR TITLE
Use `-V` for checking yosys, rather than `--version`, for more compatibility

### DIFF
--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -1650,7 +1650,7 @@ class TestVerilogInput(unittest.TestCase):
     def setUp(self):
         import subprocess
         try:
-            version = subprocess.check_output(['yosys', '--version'])
+            version = subprocess.check_output(['yosys', '-V'])
         except OSError:
             raise unittest.SkipTest('Testing Verilog input requires yosys')
         pyrtl.reset_working_block()


### PR DESCRIPTION
Older versions of Yosys before [this](https://github.com/YosysHQ/yosys/commit/b76b02358439cd04ed5cad5cb889e8b43c801ac1#diff-0669f85faa7b63a365d1c33676c94016e99ae7d2dc071e7e411150aa34695bf9) change only recognize `-V` for checking the version. This PR uses that flag in the tests instead for better compatiblity.