### PR TITLE
Improve binary wave form in Ascii trace render

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -958,7 +958,7 @@ class AsciiWaveRenderer(_WaveRendererBase):
     _tick = '-'
     _up, _down = '/', '\\'
     _x, _low, _high = 'x', '_', '-'
-    _revstart, _revstop = ' ', ' '
+    _revstart, _revstop = '', ''
 
 
 def default_renderer():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -132,50 +132,56 @@ class TraceWithBasicOpsBase(unittest.TestCase):
 class RenderTraceBase(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()
-        a, b = pyrtl.input_list('a/8 b/8')
+        a, b, c = pyrtl.input_list('a/8 b/8 c/1')
         o = pyrtl.Output()
-        o <<= a + b
+        o <<= a + b - c
 
     def check_rendered_trace(self, expected, **kwargs):
         sim = pyrtl.Simulation()
         sim.step_multiple({
             'a': [1, 4, 9, 11, 12],
             'b': [2, 23, 43, 120, 0],
+            'c': [0, 1, 1, 0, 1]
         })
         buff = io.StringIO()
         sim.tracer.render_trace(file=buff, render_cls=pyrtl.simulation.AsciiWaveRenderer,
                                 extra_line=False, **kwargs)
         self.assertEqual(buff.getvalue(), expected)
 
+    # TODO replace 'x' with something else (a little confusing since hex repr also uses it)
     def test_hex_trace(self):
         expected = (
             "  -0                       \n"
-            "a  0x1    x0x4   x0x9   x0xb   x0xc  \n"
-            "b  0x2    x0x17  x0x2b  x0x78  x0x0  \n"
+            "a 0x1  x0x4 x0x9 x0xb x0xc \n"
+            "b 0x2  x0x17x0x2bx0x78x0x0 \n"
+            "c _____/---------\____/----\n"
         )
         self.check_rendered_trace(expected)
 
-    def test_hex_trace(self):
+    def test_oct_trace(self):
         expected = (
             "  -0                            \n"
-            "a  0o1     x0o4    x0o11   x0o13   x0o14  \n"
-            "b  0o2     x0o27   x0o53   x0o170  x0o0   \n"
+            "a 0o1   x0o4  x0o11 x0o13 x0o14 \n"
+            "b 0o2   x0o27 x0o53 x0o170x0o0  \n"
+            "c ______/-----------\_____/-----\n"
         )
         self.check_rendered_trace(expected, repr_func=oct, symbol_len=None)
 
     def test_bin_trace(self):
         expected = (
             "  -0                                                \n"
-            "a  0b1         x0b100      x0b1001     x0b1011     x0b1100    \n"
-            "b  0b10        x0b10111    x0b101011   x0b1111000  x0b0       \n"
+            "a 0b1       x0b100    x0b1001   x0b1011   x0b1100   \n"
+            "b 0b10      x0b10111  x0b101011 x0b1111000x0b0      \n"
+            "c __________/-------------------\_________/---------\n"
         )
         self.check_rendered_trace(expected, repr_func=bin, symbol_len=None)
 
     def test_decimal_trace(self):
         expected = (
             "  -0                  \n"
-            "a  1     x4    x9    x11   x12  \n"
-            "b  2     x23   x43   x120  x0   \n"
+            "a 1   x4  x9  x11 x12 \n"
+            "b 2   x23 x43 x120x0  \n"
+            "c ____/-------\___/---\n"
         )
         self.check_rendered_trace(expected, repr_func=str, symbol_len=None)
 
@@ -217,9 +223,9 @@ class RenderTraceCustomBase(unittest.TestCase):
                                 extra_line=None, repr_per_name={'state': Foo}, symbol_len=None)
         expected = (
             "      -0                            \n"
-            "    i  0x1     x0x2    x0x4    x0x8    x0x0   \n"
-            "    o  0x0             x0x1    x0x2    x0x3   \n"
-            "state  Foo.A           xFoo.B  xFoo.C  xFoo.D \n"
+            "    i 0x1   x0x2  x0x4  x0x8  x0x0  \n"
+            "    o 0x0         x0x1  x0x2  x0x3  \n"
+            "state Foo.A       xFoo.BxFoo.CxFoo.D\n"
         )
         self.assertEqual(buff.getvalue(), expected)
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -148,13 +148,12 @@ class RenderTraceBase(unittest.TestCase):
                                 extra_line=False, **kwargs)
         self.assertEqual(buff.getvalue(), expected)
 
-    # TODO replace 'x' with something else (a little confusing since hex repr also uses it)
     def test_hex_trace(self):
         expected = (
             "  -0                       \n"
             "a 0x1  x0x4 x0x9 x0xb x0xc \n"
             "b 0x2  x0x17x0x2bx0x78x0x0 \n"
-            "c _____/---------\____/----\n"
+            "c _____/---------\\____/----\n"  # escaped backslash
         )
         self.check_rendered_trace(expected)
 
@@ -163,7 +162,7 @@ class RenderTraceBase(unittest.TestCase):
             "  -0                            \n"
             "a 0o1   x0o4  x0o11 x0o13 x0o14 \n"
             "b 0o2   x0o27 x0o53 x0o170x0o0  \n"
-            "c ______/-----------\_____/-----\n"
+            "c ______/-----------\\_____/-----\n"  # escaped backslash
         )
         self.check_rendered_trace(expected, repr_func=oct, symbol_len=None)
 
@@ -172,7 +171,7 @@ class RenderTraceBase(unittest.TestCase):
             "  -0                                                \n"
             "a 0b1       x0b100    x0b1001   x0b1011   x0b1100   \n"
             "b 0b10      x0b10111  x0b101011 x0b1111000x0b0      \n"
-            "c __________/-------------------\_________/---------\n"
+            "c __________/-------------------\\_________/---------\n"  # escaped backslash
         )
         self.check_rendered_trace(expected, repr_func=bin, symbol_len=None)
 
@@ -181,7 +180,7 @@ class RenderTraceBase(unittest.TestCase):
             "  -0                  \n"
             "a 1   x4  x9  x11 x12 \n"
             "b 2   x23 x43 x120x0  \n"
-            "c ____/-------\___/---\n"
+            "c ____/-------\\___/---\n"  # escaped backslash
         )
         self.check_rendered_trace(expected, repr_func=str, symbol_len=None)
 


### PR DESCRIPTION
Given this PyRTL code:
```
import pyrtl

a, b, c = pyrtl.input_list('a/8 b/8 c/1')
o = pyrtl.Output(name='o')
o <<= a + b - c

sim = pyrtl.Simulation()
sim.step_multiple({
          'a': [1, 4, 9, 11, 12],
          'b': [2, 23, 43, 120, 0],
          'c': [0, 1, 1, 0, 0],
})
sim.tracer.render_trace(render_cls=pyrtl.simulation.AsciiWaveRenderer, symbol_len=None)
sim.tracer.render_trace(symbol_len=None)
```

the binary waveforms being printed didn't aligned with wires whose bitwidth > 1. This is because it was using spaces, instead of an empty string, for Ascii waveform counterparts to the Unicode reverse escape characters (which are length zero visually).

I.e. before:
<img width="403" alt="Screen Shot 2021-07-06 at 2 21 08 PM" src="https://user-images.githubusercontent.com/2482771/124668244-6b686900-de65-11eb-8864-00df211d80dd.png">

(the top is the Ascii rendered version, and below it is the normal Unicode version).

After:
<img width="403" alt="Screen Shot 2021-07-06 at 2 18 40 PM" src="https://user-images.githubusercontent.com/2482771/124667997-12003a00-de65-11eb-932e-0741caa61edc.png">

(again, the top is the Ascii rendered version, and below the Unicode version). The binary wire `c` is aligned with the rest.

For the future, we may want to do something to differentiate between the `x` used for representing the change between values, and `x` used in the hex representation. (Before with the extra spaces, it was a little easier to see the non-binary waveforms, though they weren't aligned as already said).