### PR TITLE
Improve Verilog output when a memory doesn't have any writes

### DIFF
--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -758,24 +758,25 @@ def _to_verilog_memories(file, block, varname):
     memories = {n.op_param[1] for n in block.logic_subset('m@')}
     for m in sorted(memories, key=lambda m: m.id):
         print('    // Memory mem_{}: {}'.format(m.id, m.name), file=file)
-        writes = _net_sorted(block.logic_subset('@'), varname)
+        writes = [net for net in _net_sorted(block.logic_subset('@'), varname)
+                  if net.op_param[1] == m]
         if writes:
             print('    always @(posedge clk)', file=file)
             print('    begin', file=file)
             for net in writes:
-                if net.op_param[1] == m:
-                    t = (varname(net.args[2]), net.op_param[0],
-                         varname(net.args[0]), varname(net.args[1]))
-                    print(('        if (%s) begin\n'
-                           '            mem_%s[%s] <= %s;\n'
-                           '        end') % t, file=file)
+                t = (varname(net.args[2]), net.op_param[0],
+                     varname(net.args[0]), varname(net.args[1]))
+                print(('        if (%s) begin\n'
+                       '            mem_%s[%s] <= %s;\n'
+                       '        end') % t, file=file)
             print('    end', file=file)
-        for net in _net_sorted(block.logic_subset('m'), varname):
-            if net.op_param[1] == m:
-                dest = varname(net.dests[0])
-                m_id = net.op_param[0]
-                index = varname(net.args[0])
-                print('    assign {:s} = mem_{}[{:s}];'.format(dest, m_id, index), file=file)
+        reads = [net for net in _net_sorted(block.logic_subset('m'), varname)
+                 if net.op_param[1] == m]
+        for net in reads:
+            dest = varname(net.dests[0])
+            m_id = net.op_param[0]
+            index = varname(net.args[0])
+            print('    assign {:s} = mem_{}[{:s}];'.format(dest, m_id, index), file=file)
         print('', file=file)
 
 

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -1384,6 +1384,56 @@ endmodule
 """
 
 
+verilog_output_mems_with_no_writes = """\
+// Generated automatically via PyRTL
+// As one initial test of synthesis, map to FPGA with:
+//   yosys -p "synth_xilinx -top toplevel" thisfile.v
+
+module toplevel(clk, rst, in1, out1);
+    input clk;
+    input rst;
+    input[2:0] in1;
+    output[7:0] out1;
+
+    reg[7:0] mem_0[7:0]; //tmp0
+    reg[7:0] mem_1[255:0]; //tmp1
+
+    wire const_0_1;
+    wire[7:0] const_1_42;
+    wire[7:0] tmp2;
+
+    initial begin
+        mem_0[0]=8'ha;
+        mem_0[1]=8'h14;
+        mem_0[2]=8'h1e;
+        mem_0[3]=8'h28;
+        mem_0[4]=8'h32;
+        mem_0[5]=8'h3c;
+        mem_0[6]=8'h0;
+        mem_0[7]=8'h0;
+    end
+
+    // Combinational
+    assign const_0_1 = 1;
+    assign const_1_42 = 42;
+    assign out1 = tmp2;
+
+    // Memory mem_0: tmp0
+    assign tmp2 = mem_0[in1];
+
+    // Memory mem_1: tmp1
+    always @(posedge clk)
+    begin
+        if (const_0_1) begin
+            mem_1[tmp2] <= const_1_42;
+        end
+    end
+
+endmodule
+
+"""
+
+
 verilog_output_counter_no_reset = """\
 // Generated automatically via PyRTL
 // As one initial test of synthesis, map to FPGA with:
@@ -1567,6 +1617,21 @@ class TestVerilogOutput(unittest.TestCase):
         pyrtl.output_to_verilog(buffer)
 
         self.assertEqual(buffer.getvalue(), verilog_output_large)
+
+    def test_mems_with_no_writes(self):
+        rdata = {0: 10, 1: 20, 2: 30, 3: 40, 4: 50, 5: 60}
+        rom = pyrtl.RomBlock(8, 3, rdata, pad_with_zeros=True)
+        mem = pyrtl.MemBlock(8, 8)
+        in1 = pyrtl.Input(3, 'in1')
+        out1 = pyrtl.Output(8, 'out1')
+        w = rom[in1]
+        out1 <<= w
+        mem[w] <<= 42
+
+        buffer = io.StringIO()
+        pyrtl.output_to_verilog(buffer)
+
+        self.assertEqual(buffer.getvalue(), verilog_output_mems_with_no_writes)
 
     def check_counter_text(self, add_reset, expected):
         r = pyrtl.Register(4, reset_value=2)


### PR DESCRIPTION
This continues on the improvements from #399 by doing the check for memory writes _per memory_, rather than across all of them, when outputting Verilog.

I.e. instead of this (the empty `begin ... end`):
```
...
    // Memory mem_0: tmp0
    always @(posedge clk)
    begin
    end
    assign tmp2 = mem_0[in1];

    // Memory mem_1: tmp1
    always @(posedge clk)
    begin
        if (const_0_1) begin
            mem_1[tmp2] <= const_1_42;
        end
    end
...
```

these changes now cause the following to be produced:
```
...
    // Memory mem_0: tmp0
    assign tmp2 = mem_0[in1];

    // Memory mem_1: tmp1
    always @(posedge clk)
    begin
        if (const_0_1) begin
            mem_1[tmp2] <= const_1_42;
        end
    end
...
```
