### PR TITLE
Don't generate nands on BLIF import

### DIFF
--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -663,7 +663,9 @@ class TestInputFromBlif(unittest.TestCase):
         })
         self.assertEqual(sim.tracer.trace['o'], [0, 1, 1, 1])
 
-    def test_blif_nand_gate_correct(self):
+    def test_blif_nand_gate_to_primitives_correct(self):
+        # This tests that there should be no NAND gates generated during BLIF import;
+        # they should be converted to AND+NOT.
         blif = """\
         .model Top
         .inputs a b
@@ -675,7 +677,9 @@ class TestInputFromBlif(unittest.TestCase):
         """
         pyrtl.input_from_blif(blif)
         block = pyrtl.working_block()
-        self.assertEqual(len(block.logic_subset('n')), 1)
+        self.assertEqual(len(block.logic_subset('n')), 0)
+        self.assertEqual(len(block.logic_subset('&')), 1)
+        self.assertEqual(len(block.logic_subset('~')), 1)
         sim = pyrtl.Simulation()
         sim.step_multiple({
             'a': '0011',


### PR DESCRIPTION
In [this commit](https://github.com/UCSBarchlab/PyRTL/commit/9dc3fdbeb5e60a0490144c82f90f30bba52ac1f6#diff-a884ba1966ff1972495efd768dbcc7e9c6b8a854adcb840d4e27e3e1117a8d42R323), I updated blif import to be a little more general, but in so doing, introduced a place where `n` (nand) nets are created. The `n` net is a non-primitive in PyRTL, and should only be introduced via a call to `nand_synth()`, and so issues come up if you import a BLIF that generates a `n`, and then try to export it to Verilog, for example, where checks are made for unsupported nets.

This PR just converts any `n` seen during BLIF import into a combination of `~` and `&`.