### PR TITLE
Return special dictionaries from `net_connections()`.

### DIFF
--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -43,7 +43,7 @@ class _MemIndexed(WireVector):
 
     The normal PyRTL user should never need to be aware that this class exists,
     hence the underscore in the name.  It presents a very similar interface to
-    wiresVectors (all of the normal wirevector operations should still work),
+    WireVectors (all of the normal wirevector operations should still work),
     but if you try to *set* the value with <<= or |= then it will generate a
     _MemAssignment object rather than the normal wire assignment.
     """


### PR DESCRIPTION
Returns special dictionaries from `net_connections()` so that attempted lookups using `_MemIndexed` produce helpful error messages on what to do instead.

This should probably be removed if/when the wider issue (of the `_MemIndexed` wrapper subtly changing how block methods behave) is fixed more generally.