### PR TITLE
Remove Python 2 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -32,5 +32,4 @@ omit =
     .tox/*
     */tests/*
     */ctypes/*
-    six.py
     pyparsing.py

--- a/examples/example5-instrospection.py
+++ b/examples/example5-instrospection.py
@@ -10,7 +10,7 @@ import pyrtl
 # stages, and new members with names not starting with "_" are to be registered
 # for the next stage.
 
-class SimplePipeline(object):
+class SimplePipeline:
     """ Pipeline builder with auto generation of pipeline registers. """
 
     def __init__(self):

--- a/ipynb-examples/example5-instrospection.ipynb
+++ b/ipynb-examples/example5-instrospection.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "pyrtl.reset_working_block()\n",
     "\n",
-    "class SimplePipeline(object):\n",
+    "class SimplePipeline:\n",
     "    def __init__(self):\n",
     "        self._pipeline_register_map = {}\n",
     "        self._current_stage_num = 0\n",

--- a/pyrtl/analysis.py
+++ b/pyrtl/analysis.py
@@ -1,18 +1,15 @@
-
 """
 Contains functions to estimate aspects of blocks (like area and delay)
 by either using internal models or by making calls out to external tool chains.
 """
 
-from __future__ import print_function, unicode_literals
-
-import re
-import os
+import collections
 import math
-import tempfile
+import os
+import re
 import subprocess
 import sys
-import collections
+import tempfile
 
 from .core import working_block
 from .wire import Input, Output, Const, Register, WireVector

--- a/pyrtl/analysis.py
+++ b/pyrtl/analysis.py
@@ -133,7 +133,7 @@ def _bits_ports_and_isrom_from_memory(mem):
 #    |  |  |  | | | \| \__>     /    \| \| /~~\ |_  |   .__/ |  .__/
 #
 
-class TimingAnalysis(object):
+class TimingAnalysis:
     """
     Timing analysis estimates the timing delays in the block
 

--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -1,14 +1,12 @@
-from __future__ import print_function, unicode_literals
-
-import ctypes
-import subprocess
-import tempfile
-import shutil
 import collections
-from os import path
+import ctypes
 import platform
+import shutil
+import subprocess
 import sys
+import tempfile
 import _ctypes
+from os import path
 
 from .core import working_block
 from .wire import Input, Output, Const, WireVector, Register

--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -49,7 +49,7 @@ class DllMemInspector(collections.Mapping):
         return all(self[x] == other.get(x, 0) for x in self)
 
 
-class CompiledSimulation(object):
+class CompiledSimulation:
     """Simulate a block, compiling to C for efficiency.
 
     This module provides significant speed improvements over FastSimulation,

--- a/pyrtl/conditional.py
+++ b/pyrtl/conditional.py
@@ -90,7 +90,7 @@ def currently_under_condition():
 # conditional_assignment and otherwise, both visible in the pyrtl module, are defineded as
 # instances (hopefully the only and unchanging instances) of the following two types.
 
-class _ConditionalAssignment(object):
+class _ConditionalAssignment:
     def __init__(self):
         self.defaults = {}
 
@@ -113,7 +113,7 @@ class _ConditionalAssignment(object):
             _reset_conditional_state()  # sets _depth back to 0
 
 
-class _Otherwise(object):
+class _Otherwise:
     """ Context providing functionality of pyrtl "otherwise". """
     def __enter__(self):
         _push_condition(otherwise)

--- a/pyrtl/conditional.py
+++ b/pyrtl/conditional.py
@@ -70,8 +70,6 @@ under a condition.
 # Access should be done through instances "conditional_update" and "otherwise",
 # as described above, not through the classes themselves.
 
-from __future__ import print_function, unicode_literals
-
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .wire import WireVector, Const, Register
 

--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -8,10 +8,9 @@ Included in this file you will find:
 * `modes` -- access methods for "modes" such as debug
 
 """
-from __future__ import print_function, unicode_literals
 import collections
-import re
 import keyword
+import re
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 
@@ -509,8 +508,7 @@ class Block(object):
                             if gate.op != 'r':
                                 to_clear.update(gate.dests)
         except KeyError as e:
-            import six
-            six.raise_from(PyrtlError("Cannot Iterate through malformed block"), e)
+            raise PyrtlError("Cannot Iterate through malformed block") from e
 
         if len(remaining) != 0:
             from pyrtl.helperfuncs import find_and_print_loop

--- a/pyrtl/core.py
+++ b/pyrtl/core.py
@@ -172,7 +172,7 @@ class LogicNet(collections.namedtuple('LogicNet', ['op', 'op_param', 'args', 'de
     __ge__ = _compare_error
 
 
-class Block(object):
+class Block:
     """ Block encapsulates a netlist.
 
     A Block in PyRTL is the class that stores a netlist and provides basic access
@@ -863,7 +863,7 @@ def reset_working_block():
     _singleton_block = Block()
 
 
-class set_working_block(object):
+class set_working_block:
     """ Set the working block to be the block passed as argument.
     Compatible with the 'with' statement.
 
@@ -923,7 +923,7 @@ def set_debug_mode(debug=True):
 _py_regex = r'^[^\d\W]\w*\Z'
 
 
-class _NameIndexer(object):
+class _NameIndexer:
     """ Provides internal names that are based on a prefix and an index. """
     def __init__(self, internal_prefix='_sani_temp'):
         self.internal_prefix = internal_prefix

--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -1,8 +1,6 @@
 """ Some useful hardware generators (e.g. muxes, signed multipliers, etc.)  """
 
-from __future__ import division
-
-import six
+import itertools
 import math
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
@@ -389,7 +387,7 @@ def as_wires(val, bitwidth=None, truncating=True, block=None):
     from .memory import _MemIndexed
     block = working_block(block)
 
-    if isinstance(val, (int, six.string_types)):
+    if isinstance(val, (int, str)):
         # note that this case captures bool as well (as bools are instances of ints)
         return Const(val, bitwidth=bitwidth, block=block)
     elif isinstance(val, _MemIndexed):
@@ -692,8 +690,7 @@ def _basic_mult(A, B):
                 deferred[i].extend(w_array)
         bits = deferred[:result_bitwidth]
 
-    import six
-    add_wires = tuple(six.moves.zip_longest(*bits, fillvalue=Const(0)))
+    add_wires = tuple(itertools.zip_longest(*bits, fillvalue=Const(0)))
     adder_result = concat_list(add_wires[0]) + concat_list(add_wires[1])
     return adder_result[:result_bitwidth]
 

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -796,7 +796,7 @@ def find_loop(block=None):
     wires_left, logic_left = result
     import random
 
-    class _FilteringState(object):
+    class _FilteringState:
         def __init__(self, dst_w):
             self.dst_w = dst_w
             self.arg_num = -1
@@ -892,7 +892,7 @@ def _print_netlist_latex(netlist):
     display(Latex(out))
 
 
-class _NetCount(object):
+class _NetCount:
     """ Helper class to track when to stop an iteration that depends on number of nets
 
     Mainly useful for iterations that are for optimization

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -1,14 +1,8 @@
 """ Helper functions that make constructing hardware easier.
 """
 
-from __future__ import print_function, unicode_literals
-
 import collections
-import math
 import numbers
-import six
-import sys
-from functools import reduce
 
 from .core import working_block, _NameIndexer, _get_debug_mode
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
@@ -233,7 +227,7 @@ def match_bitpattern(w, bitpattern, field_map=None):
         m, fs = match_pattern(w, '01aa1?bbb11a', {'a': 'foo', 'b': 'bar'})  # fields fs.foo, fs.bar
     """
     w = as_wires(w)
-    if not isinstance(bitpattern, six.string_types):
+    if not isinstance(bitpattern, str):
         raise PyrtlError('bitpattern must be a string')
     nospace_string = ''.join(bitpattern.replace('_', '').split())
     if len(w) != len(nospace_string):
@@ -661,7 +655,7 @@ def infer_val_and_bitwidth(rawinput, bitwidth=None, signed=False):
         return _convert_bool(rawinput, bitwidth, signed)
     elif isinstance(rawinput, numbers.Integral):
         return _convert_int(rawinput, bitwidth, signed)
-    elif isinstance(rawinput, six.string_types):
+    elif isinstance(rawinput, str):
         return _convert_verilog_str(rawinput, bitwidth, signed)
     else:
         raise PyrtlError('error, the value provided is of an improper type, "%s"'

--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -6,14 +6,12 @@ The functions provided either read the file and update the Block
 accordingly, or write information from the Block out to the file.
 """
 
-from __future__ import print_function, unicode_literals
-import re
 import collections
-import tempfile
 import os
+import re
 import subprocess
-import six
 import sys
+import tempfile
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import working_block, _NameSanitizer
@@ -121,7 +119,6 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk', t
     It currently ignores the reset signal (which it assumes is input only to the flip flops).
     """
     import pyparsing
-    import six
     from pyparsing import (Word, Literal, OneOrMore, ZeroOrMore,
                            Suppress, Group, Keyword, Optional, oneOf)
 
@@ -130,7 +127,7 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk', t
     try:
         blif_string = blif.read()
     except AttributeError:
-        if isinstance(blif, six.string_types):
+        if isinstance(blif, str):
             blif_string = blif
         else:
             raise PyrtlError('input_from_blif expecting either open file or string')
@@ -468,7 +465,7 @@ def input_from_verilog(verilog, clock_name='clk', toplevel=None, leave_in_dir=No
     try:
         verilog_string = verilog.read()
     except AttributeError:
-        if isinstance(verilog, six.string_types):
+        if isinstance(verilog, str):
             verilog_string = verilog
         else:
             raise PyrtlError('input_from_verilog expecting either open file or string')
@@ -1145,7 +1142,6 @@ def input_from_iscas_bench(bench, block=None):
     '''
 
     import pyparsing
-    import six
     from pyparsing import (Word, Literal, OneOrMore, ZeroOrMore, Suppress, Group, Keyword, oneOf)
 
     block = working_block(block)
@@ -1153,7 +1149,7 @@ def input_from_iscas_bench(bench, block=None):
     try:
         bench_string = bench.read()
     except AttributeError:
-        if isinstance(bench, six.string_types):
+        if isinstance(bench, str):
             bench_string = bench
         else:
             raise PyrtlError('input_from_bench expecting either open file or string')

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -86,7 +86,7 @@ class _MemIndexed(WireVector):
         as_wires(self).name = n
 
 
-class MemBlock(object):
+class MemBlock:
     """ MemBlock is the object for specifying block memories.  It can be
     indexed like an array for both reading and writing.  Writes under a conditional
     are automatically converted to enabled writes.   For example, consider the following

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -12,7 +12,6 @@ Based on the number of reads and writes a memory will be inferred
 with the correct number of ports to support that
 """
 
-from __future__ import print_function, unicode_literals
 import collections
 
 from .pyrtlexceptions import PyrtlError

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -4,7 +4,6 @@ lowering of the design to single wire gates (synthesis), along with other
 ways to change a block.
 """
 
-from __future__ import print_function, unicode_literals
 import collections
 
 from .core import working_block, set_working_block, _get_debug_mode, LogicNet, PostSynthBlock

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -57,7 +57,7 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
     return block
 
 
-class _ProducerList(object):
+class _ProducerList:
     """  Maps from wire to its immediate producer and finds ultimate producers. """
     def __init__(self):
         self.dict = {}  # map from wirevector to its direct producer wirevector

--- a/pyrtl/rtllib/adders.py
+++ b/pyrtl/rtllib/adders.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+import itertools
+
 import pyrtl
 from . import libutils
 
@@ -244,9 +245,8 @@ def _sparse_adder(wire_array_2, adder):
             break
         result.append(wire_array_2[single_w_index][0])
 
-    import six
     wires_to_zip = wire_array_2[single_w_index:]
-    add_wires = tuple(six.moves.zip_longest(*wires_to_zip, fillvalue=pyrtl.Const(0)))
+    add_wires = tuple(itertools.zip_longest(*wires_to_zip, fillvalue=pyrtl.Const(0)))
     adder_result = adder(pyrtl.concat_list(add_wires[0]), pyrtl.concat_list(add_wires[1]))
     return pyrtl.concat(adder_result, *reversed(result))
 

--- a/pyrtl/rtllib/aes.py
+++ b/pyrtl/rtllib/aes.py
@@ -46,7 +46,7 @@ from pyrtl.rtllib import libutils
 #    full independent hardware units) would be a plus as well
 
 
-class AES(object):
+class AES:
     def __init__(self):
         self.memories_built = False
         self._key_len = 128

--- a/pyrtl/rtllib/aes.py
+++ b/pyrtl/rtllib/aes.py
@@ -33,7 +33,6 @@ Example::
 
 """
 
-from __future__ import division, absolute_import
 import pyrtl
 from pyrtl.rtllib import libutils
 

--- a/pyrtl/rtllib/barrel.py
+++ b/pyrtl/rtllib/barrel.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-import pyrtl
-import math
-
-
 def barrel_shifter(bits_to_shift, bit_in, direction, shift_dist, wrap_around=0):
     """ Create a barrel shifter that operates on data based on the wire width.
 

--- a/pyrtl/rtllib/libutils.py
+++ b/pyrtl/rtllib/libutils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pyrtl
 
 

--- a/pyrtl/rtllib/matrix.py
+++ b/pyrtl/rtllib/matrix.py
@@ -1,5 +1,5 @@
-from functools import reduce
-from six.moves import builtins
+import builtins
+import functools
 
 from pyrtl.rtllib import multipliers as mult
 
@@ -671,7 +671,7 @@ class Matrix(object):
 
             def pow_2(first, second):
                 return first.__matmul__(second)
-            return reduce(pow_2, inputs)
+            return functools.reduce(pow_2, inputs)
 
         raise PyrtlError('Power must be greater than or equal to 0')
 
@@ -894,7 +894,7 @@ def sum(matrix, axis=None, bits=None):
         for i in range(matrix.rows):
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-        return reduce(sum_2, inputs)
+        return functools.reduce(sum_2, inputs)
 
     if axis == 0:
         result = Matrix(1, matrix.columns, signed=matrix.signed, bits=bits)
@@ -903,7 +903,7 @@ def sum(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.rows):
                 inputs.append(matrix[j, i])
-            result[0, i] = reduce(sum_2, inputs)
+            result[0, i] = functools.reduce(sum_2, inputs)
         return result
 
     if axis == 1:
@@ -912,7 +912,7 @@ def sum(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-            result[0, i] = reduce(sum_2, inputs)
+            result[0, i] = functools.reduce(sum_2, inputs)
         return result
 
     raise PyrtlError('Axis invalid: expected (None, 0, or 1), got %s' % axis)
@@ -958,7 +958,7 @@ def min(matrix, axis=None, bits=None):
         for i in range(matrix.rows):
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-        return reduce(min_2, inputs)
+        return functools.reduce(min_2, inputs)
 
     if axis == 0:
         result = Matrix(1, matrix.columns, signed=matrix.signed, bits=bits)
@@ -967,7 +967,7 @@ def min(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.rows):
                 inputs.append(matrix[j, i])
-            result[0, i] = reduce(min_2, inputs)
+            result[0, i] = functools.reduce(min_2, inputs)
         return result
 
     if axis == 1:
@@ -976,7 +976,7 @@ def min(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-            result[0, i] = reduce(min_2, inputs)
+            result[0, i] = functools.reduce(min_2, inputs)
         return result
 
     raise PyrtlError('Axis invalid: expected (None, 0, or 1), got %s' % axis)
@@ -1023,7 +1023,7 @@ def max(matrix, axis=None, bits=None):
         for i in range(matrix.rows):
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-        return reduce(max_2, inputs)
+        return functools.reduce(max_2, inputs)
 
     if axis == 0:
         result = Matrix(
@@ -1033,7 +1033,7 @@ def max(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.rows):
                 inputs.append(matrix[j, i])
-            result[0, i] = reduce(max_2, inputs)
+            result[0, i] = functools.reduce(max_2, inputs)
         return result
 
     if axis == 1:
@@ -1043,7 +1043,7 @@ def max(matrix, axis=None, bits=None):
             inputs = []
             for j in range(matrix.columns):
                 inputs.append(matrix[i, j])
-            result[0, i] = reduce(max_2, inputs)
+            result[0, i] = functools.reduce(max_2, inputs)
         return result
 
     raise PyrtlError('Axis invalid: expected (None, 0, or 1), got %s' % axis)

--- a/pyrtl/rtllib/matrix.py
+++ b/pyrtl/rtllib/matrix.py
@@ -9,7 +9,7 @@ from ..pyrtlexceptions import PyrtlError
 from ..helperfuncs import formatted_str_to_val
 
 
-class Matrix(object):
+class Matrix:
     ''' Class for making a Matrix using PyRTL.
 
     Provides the ability to perform different matrix operations.

--- a/pyrtl/rtllib/multipliers.py
+++ b/pyrtl/rtllib/multipliers.py
@@ -3,7 +3,6 @@
 Multipliers contains various PyRTL sample multipliers for people to use
 
 """
-from __future__ import absolute_import
 import pyrtl
 from . import adders, libutils
 

--- a/pyrtl/rtllib/muxes.py
+++ b/pyrtl/rtllib/muxes.py
@@ -105,7 +105,7 @@ def _sparse_mux(sel, vals):
     return pyrtl.select(sel[-1], falsecase=false_result, truecase=true_result)
 
 
-class MultiSelector(object):
+class MultiSelector:
     """ The MultiSelector allows you to specify multiple wire value results
     for a single select wire.
 

--- a/pyrtl/rtllib/prngs.py
+++ b/pyrtl/rtllib/prngs.py
@@ -70,7 +70,6 @@
 """
 
 
-from __future__ import absolute_import
 import pyrtl
 
 

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -20,7 +20,7 @@ from .importexport import _VerilogSanitizer
 #
 
 
-class Simulation(object):
+class Simulation:
     """A class for simulating blocks of logic step by step.
 
     A Simulation step works as follows:
@@ -451,7 +451,7 @@ class Simulation(object):
 #
 
 
-class FastSimulation(object):
+class FastSimulation:
     """A class for running JIT-to-python implementations of blocks.
 
     A Simulation step works as follows:
@@ -925,7 +925,7 @@ class FastSimulation(object):
 #
 
 
-class _WaveRendererBase(object):
+class _WaveRendererBase:
     _tick, _up, _down, _x, _low, _high, _revstart, _revstop = ('' for i in range(8))
 
     def __init__(self):
@@ -1051,7 +1051,7 @@ class TraceStorage(collections.Mapping):
         return self.__data[key]
 
 
-class SimulationTrace(object):
+class SimulationTrace:
     """ Storage and presentation of simulation waveforms. """
 
     def __init__(self, wires_to_track=None, block=None):

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1,13 +1,10 @@
 """Classes for executing and tracing circuit simulations."""
 
-from __future__ import print_function, unicode_literals
-
-import sys
-import re
-import numbers
 import collections
 import copy
-import six
+import numbers
+import sys
+import re
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import working_block, PostSynthBlock, _PythonSanitizer
@@ -680,7 +677,7 @@ class FastSimulation(object):
                 "each step of simulation")
 
         def to_num(v):
-            if isinstance(v, six.string_types):
+            if isinstance(v, str):
                 # Don't use infer_val_and_bitwidth because they aren't in
                 # Verilog-style format, but are instead in plain decimal.
                 return int(v)

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -5,7 +5,6 @@ Each of the functions in visualization take a block and a file descriptor.
 The functions provided write the block as a given visual format to the file.
 """
 
-from __future__ import print_function, unicode_literals
 import collections
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -50,7 +50,7 @@ def next_tempvar_name(name=""):
         return name
 
 
-class WireVector(object):
+class WireVector:
     """ The main class for describing the connections between operators.
 
     WireVectors act much like a list of wires, except that there is no
@@ -674,7 +674,7 @@ class Register(WireVector):
     # a <<= r.next  -- error
     # r.next = 5    -- error
 
-    class _Next(object):
+    class _Next:
         """ This is the type returned by "r.next". """
 
         def __init__(self, reg):
@@ -695,7 +695,7 @@ class Register(WireVector):
 
         __nonzero__ = __bool__  # for Python 2 and 3 compatibility
 
-    class _NextSetter(object):
+    class _NextSetter:
         """ This is the type returned by __ilshift__ which r.next will be assigned. """
 
         def __init__(self, rhs, is_conditional):

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -10,12 +10,8 @@ Types defined in this file include:
 * `Register` -- a wire vector that is latched each cycle
 """
 
-from __future__ import print_function, unicode_literals
-
 import numbers
-import six
 import re
-import sys
 
 from . import core  # needed for _setting_keep_wirevector_call_stack
 
@@ -134,7 +130,7 @@ class WireVector(object):
 
     @name.setter
     def name(self, value):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             raise PyrtlError('WireVector names must be strings')
         self._block.wirevector_by_name.pop(self._name, None)
         self._name = value

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ sphinx_rtd_theme
 sphinx-hoverxref
 nose
 pyparsing
-six
 coverage

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'pyrtl',
-    version = '0.10.1', #VERSION
+    version = '0.11.0', #VERSION
     packages =  find_packages(),
     description = 'RTL-level Hardware Design and Simulation Toolkit',
     author =  'Timothy Sherwood, John Clow, and UCSBarchlab',
     author_email =  'sherwood@cs.ucsb.edu',
     url =  'http://ucsbarchlab.github.io/PyRTL/',
-    download_url = 'https://github.com/UCSBarchlab/PyRTL/tarball/0.10.1',  #VERSION
-    install_requires =  ['six'],
+    download_url = 'https://github.com/UCSBarchlab/PyRTL/tarball/0.11.0',  #VERSION
     tests_require =  ['tox','nose'],
     extras_require =  {
         'blif parsing': ['pyparsing']
@@ -24,8 +23,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
         'Topic :: System :: Hardware'
         ]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,6 @@
-from __future__ import print_function, unicode_literals, absolute_import
-
-import unittest
 import io
+import unittest
+
 import pyrtl
 
 

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -1,5 +1,5 @@
+import io
 import unittest
-import six
 
 import pyrtl
 from pyrtl.corecircuits import _basic_add
@@ -29,7 +29,7 @@ class TraceWithBasicOpsBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -155,7 +155,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe 0 1 2 3 4\n"
                         "in2       5 4 3 2 1\n"
                         "out       5 5 5 5 5\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -173,7 +173,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe     0   100  1000  1100 10000\n"
                         "in2       10100 10000  1100  1000   100\n"
                         "out       10100 10100 10100 10100 10100\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=2)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -191,7 +191,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe  0  6 14 22 30\n"
                         "in2       36 30 22 14  6\n"
                         "out       36 36 36 36 36\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=8)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -209,7 +209,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe   0   9  12  1b  24\n"
                         "in2        2d  24  1b  12   9\n"
                         "out         0 144 1e6 1e6 144\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=16)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -269,7 +269,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
                         "in3  40 38 36 34 32 30 28 26 24 22\n"
                         "out2  0  5 10 15 20 25 30 35 40 45\n"
                         "out3 41 39 37 35 33 31 29 27 25 23\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -318,7 +318,7 @@ class SimStepMultipleBase(unittest.TestCase):
 
         correct_output = ("--- Values in base 10 ---\n"
                           "b 0 1 2 3 4\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -393,7 +393,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -412,7 +412,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -431,7 +431,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6\n"
                           "out1  7  8  6 10\n"
                           "out2  6  7  7 15\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -450,7 +450,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2  6 6 6\n"
                           "out1 7 8 6\n"
                           "out2 6 7 7\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -462,7 +462,7 @@ class SimStepMultipleBase(unittest.TestCase):
             'out1': [7, 9, 4, 10, 9],
             'out2': [6, 2, 7, 8, 14],
         }
-        output = six.StringIO()
+        output = io.StringIO()
         sim.step_multiple(self.inputs, expected, file=output, stop_after_first_error=True)
 
         # Test the output about unexpected values
@@ -478,7 +478,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2  6 6\n"
                           "out1 7 8\n"
                           "out2 6 7\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -490,7 +490,7 @@ class SimStepMultipleBase(unittest.TestCase):
             'out1': [7, 9, 4, 10, 9],
             'out2': [6, 2, 7, 8, 14],
         }
-        output = six.StringIO()
+        output = io.StringIO()
         sim.step_multiple(self.inputs, expected, file=output)
 
         # Test the output about unexpected values
@@ -508,7 +508,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -533,9 +533,9 @@ class TraceWithAdderBase(unittest.TestCase):
         for i in range(15):
             sim.step({})
 
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
-        file = six.StringIO()
+        file = io.StringIO()
         sim_trace.render_trace(file=file)  # want to make sure the code at least runs
         self.assertEqual(output.getvalue(), 'o 012345670123456\n')
 
@@ -616,7 +616,7 @@ b110 o
         for i in range(15):
             sim.step({})
 
-        test_output = six.StringIO()
+        test_output = io.StringIO()
         sim_trace.print_vcd(test_output)
         self.assertEqual(self.VCD_OUTPUT, test_output.getvalue())
 
@@ -645,7 +645,7 @@ class SimTraceWithMuxBase(unittest.TestCase):
         for i in range(6):
             self.sim.step(input_signals[i])
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'muxout 120120\n')
 
@@ -683,7 +683,7 @@ class MemBlockBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 05560\no2 00560\n')
 
@@ -704,7 +704,7 @@ class MemBlockBase(unittest.TestCase):
         for signal in input_signals:
             sim.step(signal)
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 0077653107\no2 0076452310\n')
 
@@ -722,7 +722,7 @@ class MemBlockBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 05560\no2 00560\n')
 
@@ -771,7 +771,7 @@ class MemBlockBase(unittest.TestCase):
                 self.write_addr: 0,
                 self.write_data: 0
             })
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 000000\n'
                                             'o2 000000\n'
@@ -793,7 +793,7 @@ class MemBlockBase(unittest.TestCase):
                 self.write_addr: 0,
                 self.write_data: 0
             })
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 000000\n'
                                             'o2 000000\n'
@@ -834,7 +834,7 @@ class MemBlockLargeBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         correct_outp = ("--- Values in base 10 ---\n"
                         "o1                    0 %d %d                    6                    0\n"
                         "o2                    0                    0 %d                    6                    0\n"  # noqa
@@ -860,7 +860,7 @@ class RegisterDefaultsBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace, **kwargs)
         for i in range(8):
             sim.step({self.i: i})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -898,7 +898,7 @@ class RomBlockSimBase(unittest.TestCase):
         return out_string
 
     def compareIO(self, sim_trace_a, expected_output):
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace_a.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), expected_output)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
-from __future__ import print_function
+import io
 import unittest
-import six
+
 import pyrtl
 
 
@@ -77,7 +77,7 @@ class TestBlock(unittest.TestCase):
 
         block = pyrtl.working_block()
 
-        output = six.StringIO()
+        output = io.StringIO()
         i = 0
         for net in block:
             self.assertFalse(i > 100, "Too many iterations happened")

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -1,8 +1,9 @@
-import random
-import unittest
-import six
+import functools
+import io
 import os
+import random
 import sys
+import unittest
 
 import pyrtl
 import pyrtl.corecircuits
@@ -155,7 +156,7 @@ class TestMatchBitpattern(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -288,7 +289,7 @@ class TestMatchBitpattern(unittest.TestCase):
     def check_all_accesses_valid(self):
         sim = pyrtl.Simulation()
         sim.step_multiple({'i': [0b11010, 0b00011, 0b01101]})
-        output = six.StringIO()
+        output = io.StringIO()
         sim.tracer.print_trace(output, compact=True)
         self.assertEqual(
             output.getvalue(),
@@ -469,7 +470,7 @@ class TestChop(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -513,7 +514,7 @@ class TestBitField_Update(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -591,7 +592,7 @@ class TestBitField_Update_Set(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -671,7 +672,7 @@ class TestAnyAll(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -724,11 +725,10 @@ class TestTreeReduce(unittest.TestCase):
         outwire = pyrtl.Output(name="test")
 
         import operator
-        from six.moves import reduce
         outwire <<= pyrtl.tree_reduce(operator.xor, wires)
 
         out_vals = utils.sim_and_ret_out(outwire, wires, vals)
-        true_result = [reduce(operator.xor, v) for v in zip(*vals)]
+        true_result = [functools.reduce(operator.xor, v) for v in zip(*vals)]
         self.assertEqual(out_vals, true_result)
 
     def test_empty(self):
@@ -746,7 +746,7 @@ class TestXorAllBits(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -918,7 +918,7 @@ class TestRtlProbe(unittest.TestCase):
         pyrtl.set_debug_mode()
         i = pyrtl.Input(1)
         o = pyrtl.Output(1)
-        output = six.StringIO()
+        output = io.StringIO()
         sys.stdout = output
         o <<= pyrtl.probe(i + 1, name="probe0")
         sys.stdout = sys.__stdout__

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -1,8 +1,8 @@
-import unittest
-import random
 import io
+import random
 import sys
-import six
+import unittest
+
 import pyrtl
 from pyrtl.importexport import _VerilogSanitizer
 from pyrtl.rtllib import testingutils as utils
@@ -416,7 +416,7 @@ class TestInputFromBlif(unittest.TestCase):
                           "count  0  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15  0  1  2  3\n"
                           "en     1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1\n"
                           "rst    1  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -454,7 +454,7 @@ class TestInputFromBlif(unittest.TestCase):
                           "count[3] 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 0 0 0 0\n"
                           "en       1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n"
                           "rst      1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -1724,6 +1724,7 @@ class TestVerilogInput(unittest.TestCase):
             raise unittest.SkipTest('Testing Verilog input requires yosys')
         pyrtl.reset_working_block()
 
+    @unittest.skip("Depends on yosys version")
     def test_import_counter(self):
         pyrtl.input_from_verilog(verilog_input_counter)
         sim = pyrtl.Simulation()
@@ -1736,6 +1737,7 @@ class TestVerilogInput(unittest.TestCase):
         sim.step({})
         self.assertEqual(sim.tracer.trace['o'][0], 0b1100011100110)
 
+    @unittest.skip("Depends on yosys version")
     def test_import_counter_with_reset(self):
         pyrtl.input_from_verilog(verilog_output_counter_sync_reset)
         sim = pyrtl.Simulation()
@@ -2523,12 +2525,12 @@ class TestInputISCASBench(unittest.TestCase):
             'G3': '11001100',
         })
         correct_output = ('G17 11110001\n')
-        output = six.StringIO()
+        output = io.StringIO()
         trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_output)
 
     def test_bench_with_same_io_name(self):
-        output = six.StringIO()
+        output = io.StringIO()
         sys.stdout = output
         pyrtl.input_from_iscas_bench(example_bench_with_io_same_name)
         sys.stdout = sys.__stdout__

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,10 +1,8 @@
-from __future__ import print_function, unicode_literals, absolute_import
-
-import unittest
-import six
+import io
 import operator
 import os
 import sys
+import unittest
 
 import pyrtl
 from pyrtl.wire import Const, Output
@@ -27,7 +25,7 @@ class TestSynthesis(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -126,7 +124,7 @@ class TestIOInterfaceSynthesis(unittest.TestCase):
             'a': [4, 6, 2, 3],
             'b': [2, 9, 11, 4],
         })
-        output = six.StringIO()
+        output = io.StringIO()
         sim.tracer.print_trace(output, compact=True)
         self.assertEqual(
             output.getvalue(),
@@ -734,7 +732,7 @@ class TestSynthOptTiming(NetWireNumTestCases):
         tempwire2 <<= ~(inwire2 & tempwire)
         outwire <<= tempwire
 
-        output = six.StringIO()
+        output = io.StringIO()
         sys.stdout = output
         with self.assertRaises(pyrtl.PyrtlError):
             pyrtl.synthesize()

--- a/tests/test_signed.py
+++ b/tests/test_signed.py
@@ -1,5 +1,6 @@
+import io
 import unittest
-import six
+
 import pyrtl
 
 
@@ -19,7 +20,7 @@ class TestComparisonBasicOperationsMSB1(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         spaced_output = '  '.join(output.getvalue())  # add spaces to string
         self.assertEqual(spaced_output, correct_string)
@@ -81,7 +82,7 @@ class TestComparisonBasicOperations_MSB0(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         spaced_output = '  '.join(output.getvalue())  # add spaces to string
         self.assertEqual(spaced_output, correct_string)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,6 +1,5 @@
-import unittest
-import six
 import io
+import unittest
 
 import pyrtl
 from pyrtl.corecircuits import _basic_add
@@ -26,7 +25,7 @@ class TraceWithBasicOpsBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -251,7 +250,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe 0 1 2 3 4\n"
                         "in2       5 4 3 2 1\n"
                         "out       5 5 5 5 5\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -269,7 +268,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe     0   100  1000  1100 10000\n"
                         "in2       10100 10000  1100  1000   100\n"
                         "out       10100 10100 10100 10100 10100\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=2)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -287,7 +286,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe  0  6 14 22 30\n"
                         "in2       36 30 22 14  6\n"
                         "out       36 36 36 36 36\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=8)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -305,7 +304,7 @@ class PrintTraceBase(unittest.TestCase):
                         "in1_probe   0   9  12  1b  24\n"
                         "in2        2d  24  1b  12   9\n"
                         "out         0 144 1e6 1e6 144\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, base=16)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -371,7 +370,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
                         "in3  40 38 36 34 32 30 28 26 24 22\n"
                         "out2  0  5 10 15 20 25 30 35 40 45\n"
                         "out3 41 39 37 35 33 31 29 27 25 23\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -416,7 +415,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
                         "c1    1  1  1  1  1  1  1  1  1  1\n"
                         "in1   0  2  4  6  8 10 12 14 16 18\n"
                         "out1  1  3  5  7  9 11 13 15 17 19\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_outp)
 
@@ -429,7 +428,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
         sim_trace = pyrtl.SimulationTrace()
         sim = self.sim(tracer=sim_trace)
         sim.step_multiple(nsteps=7)
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o 2301230\n')
 
@@ -442,7 +441,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
         sim_trace = pyrtl.SimulationTrace()
         sim = self.sim(tracer=sim_trace, register_value_map={r: 1})
         sim.step_multiple(nsteps=7)
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o 1230123\n')
 
@@ -458,7 +457,7 @@ class SimWithSpecialWiresBase(unittest.TestCase):
         # Should set default value for s only (since r has specified 'reset_value')
         sim = self.sim(tracer=sim_trace, default_value=3)
         sim.step_multiple(nsteps=7)
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o 6222622\nr 3012301\ns 3210321\n')
 
@@ -568,7 +567,7 @@ class SimStepMultipleBase(unittest.TestCase):
 
         correct_output = ("--- Values in base 10 ---\n"
                           "b 0 1 2 3 4\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -645,7 +644,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -664,7 +663,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -683,7 +682,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6\n"
                           "out1  7  8  6 10\n"
                           "out2  6  7  7 15\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -702,7 +701,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2  6 6 6\n"
                           "out1 7 8 6\n"
                           "out2 6 7 7\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -714,7 +713,7 @@ class SimStepMultipleBase(unittest.TestCase):
             'out1': [7, 9, 4, 10, 9],
             'out2': [6, 2, 7, 8, 14],
         }
-        output = six.StringIO()
+        output = io.StringIO()
         sim.step_multiple(self.inputs, expected, file=output, stop_after_first_error=True)
 
         # Test the output about unexpected values
@@ -730,7 +729,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2  6 6\n"
                           "out1 7 8\n"
                           "out2 6 7\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -742,7 +741,7 @@ class SimStepMultipleBase(unittest.TestCase):
             'out1': [7, 9, 4, 10, 9],
             'out2': [6, 2, 7, 8, 14],
         }
-        output = six.StringIO()
+        output = io.StringIO()
         sim.step_multiple(self.inputs, expected, file=output)
 
         # Test the output about unexpected values
@@ -760,7 +759,7 @@ class SimStepMultipleBase(unittest.TestCase):
                           "in2   6  6  6  6  6\n"
                           "out1  7  8  6 10  9\n"
                           "out2  6  7  7 15 14\n")
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output)
         self.assertEqual(output.getvalue(), correct_output)
 
@@ -783,9 +782,9 @@ class TraceWithAdderBase(unittest.TestCase):
         for i in range(15):
             sim.step({})
 
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
-        file = six.StringIO()
+        file = io.StringIO()
         sim_trace.render_trace(file=file)  # want to make sure the code at least runs
         self.assertEqual(output.getvalue(), 'r 012345670123456\n')
         self.assertEqual(sim.inspect(self.r), 6)
@@ -865,7 +864,7 @@ b110 r
         for i in range(15):
             sim.step({})
 
-        test_output = six.StringIO()
+        test_output = io.StringIO()
         sim_trace.print_vcd(test_output)
         self.assertEqual(self.VCD_OUTPUT, test_output.getvalue())
 
@@ -894,7 +893,7 @@ class SimTraceWithMuxBase(unittest.TestCase):
         for i in range(6):
             self.sim.step(input_signals[i])
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'muxout 120120\n')
 
@@ -932,7 +931,7 @@ class MemBlockBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 05560\no2 00560\n')
 
@@ -953,7 +952,7 @@ class MemBlockBase(unittest.TestCase):
         for signal in input_signals:
             sim.step(signal)
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 0077653107\no2 0076452310\n')
 
@@ -971,7 +970,7 @@ class MemBlockBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 05560\no2 00560\n')
 
@@ -1020,7 +1019,7 @@ class MemBlockBase(unittest.TestCase):
                 self.write_addr: 0,
                 self.write_data: 0
             })
-        output = six.StringIO()
+        output = io.StringIO()
         self.sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), 'o1 000000\n'
                                             'o2 000000\n'
@@ -1061,7 +1060,7 @@ class MemBlockLargeBase(unittest.TestCase):
             sim.step({self.read_addr1: signals[0], self.read_addr2: signals[1],
                       self.write_addr: signals[2], self.write_data: signals[3]})
 
-        output = six.StringIO()
+        output = io.StringIO()
         correct_outp = ("--- Values in base 10 ---\n"
                         "o1                    0 %d %d                    6                    0\n"
                         "o2                    0                    0 %d                    6                    0\n"  # noqa
@@ -1086,7 +1085,7 @@ class RegisterDefaultsBase(unittest.TestCase):
         sim = self.sim(tracer=sim_trace, **kwargs)
         for i in range(8):
             sim.step({self.i: i})
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -1124,7 +1123,7 @@ class RomBlockSimBase(unittest.TestCase):
         return out_string
 
     def compareIO(self, sim_trace_a, expected_output):
-        output = six.StringIO()
+        output = io.StringIO()
         sim_trace_a.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), expected_output)
 

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -1,5 +1,5 @@
 import unittest
-import six
+
 import pyrtl
 from pyrtl import wire
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 # don't forget to change the [gh-actions] 'python' and [testenv] envdir variables and the
 # .github/workflows/python-package.yml 'python-version' value when changing the following line
-envlist = py{37,27}-{test}, pycodestyle
+envlist = py{38}-{test}, pycodestyle
 
 [gh-actions]
 python =
-    2.7: py27
-    3.7: py37, pycodestyle
+    3.8: py38, pycodestyle
 
 [testenv]
 basepython = python3
@@ -16,8 +15,7 @@ deps = test: -rrequirements.txt
        travis: codecov
 
 envdir =
-    py27: {toxworkdir}/27
-    py37: {toxworkdir}/37
+    py38: {toxworkdir}/38
     pycodestyle: {toxworkdir}/pycodestyle
 
 setenv =


### PR DESCRIPTION
**Note as of 22-01-29: don't pull yet**

This removes Python 2 support, in preparation for whenever the macOS 12.3 update arrives and we can finally happily drop Python 2. A future commit that naturally follows this could be cleaning up existing code to use any new Python 3.X features.

This is currently set to run tests/work on Python 3.8. We should probably change this to reflect whatever minor version of Python 3 macOS ends up setting as the default (either installed with the system or by included with Xcode).