### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/pyrtl/compilesim.py
+++ b/pyrtl/compilesim.py
@@ -4,7 +4,6 @@ import ctypes
 import subprocess
 import tempfile
 import shutil
-import collections
 from os import path
 import platform
 import sys
@@ -16,11 +15,16 @@ from .memory import MemBlock, RomBlock
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .simulation import SimulationTrace, _trace_sort_key
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
 
 __all__ = ['CompiledSimulation']
 
 
-class DllMemInspector(collections.Mapping):
+class DllMemInspector(Mapping):
     """ Dictionary-like access to a hashmap in a CompiledSimulation. """
 
     def __init__(self, sim, mem):

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -5,7 +5,6 @@ from __future__ import print_function, unicode_literals
 import sys
 import re
 import numbers
-import collections
 import copy
 import six
 
@@ -15,6 +14,11 @@ from .wire import Input, Register, Const, Output, WireVector
 from .memory import RomBlock
 from .helperfuncs import check_rtl_assertions, _currently_in_jupyter_notebook
 from .importexport import _VerilogSanitizer
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 # ----------------------------------------------------------------
 #    __                         ___    __
@@ -1028,7 +1032,7 @@ def _trace_sort_key(w):
     return [tryint(c) for c in re.split('([0-9]+)', w)]
 
 
-class TraceStorage(collections.Mapping):
+class TraceStorage(Mapping):
     __slots__ = ('__data',)
 
     def __init__(self, wvs):


### PR DESCRIPTION
Fixes #410 