### PR TITLE
A collection of changes that should make tox runs pass

### DIFF
--- a/examples/example4-debuggingtools.py
+++ b/examples/example4-debuggingtools.py
@@ -71,7 +71,7 @@ print('\n')
 # verify the correctness of the first adder
 
 for i in range(len(vals1)):
-    assert(sim_trace.trace['debug_out'][i] == sim_trace.trace['in1'][i] + sim_trace.trace['in2'][i])
+    assert sim_trace.trace['debug_out'][i] == sim_trace.trace['in1'][i] + sim_trace.trace['in2'][i]
 
 
 # --- Probe ----

--- a/pyrtl/conditional.py
+++ b/pyrtl/conditional.py
@@ -263,7 +263,7 @@ def _current_select():
 
     # helper to create the conjuction of predicates
     def and_with_possible_none(a, b):
-        assert(a is not None or b is not None)
+        assert a is not None or b is not None
         if a is None:
             return b
         if b is None:

--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -395,7 +395,7 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk', t
         def twire(w):
             return subckt.twire(w)
 
-        if(command['C'] not in ff_clk_set):
+        if command['C'] not in ff_clk_set:
             ff_clk_set.add(command['C'])
 
         # Create register and assign next state to D and output to Q
@@ -418,7 +418,7 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk', t
         def opt_twire(w):
             return twire(w) if w is not None else None
 
-        if(command['C'] not in ff_clk_set):
+        if command['C'] not in ff_clk_set:
             ff_clk_set.add(command['C'])
 
         regname = command['Q'] + '_reg'
@@ -487,7 +487,7 @@ def input_from_blif(blif, block=None, merge_io_vectors=True, clock_name='clk', t
             formal = fa['formal']
             actual = fa['actual']
             if actual in parent.clk_set:
-                assert(formal in subckt.clk_set)
+                assert formal in subckt.clk_set
                 # We didn't create an input wire corresponding to this.
                 continue
             elif formal in subckt.inputs:
@@ -675,9 +675,9 @@ class _VerilogSanitizer(_NameSanitizer):
                                                 map_valid_vals, self._extra_checks)
 
     def _extra_checks(self, str):
-        return(str not in self._verilog_reserved_set  # is not a Verilog reserved keyword
-               and str != 'clk'                       # not the clock signal
-               and len(str) <= 1024)                  # not too long to be a Verilog id
+        return (str not in self._verilog_reserved_set  # is not a Verilog reserved keyword
+                and str != 'clk'                       # not the clock signal
+                and len(str) <= 1024)                  # not too long to be a Verilog id
 
 
 def _verilog_vector_size_decl(n):

--- a/pyrtl/rtllib/adders.py
+++ b/pyrtl/rtllib/adders.py
@@ -121,7 +121,7 @@ def _cla_adder_unit(a, b, cin):
     """
     gen = a & b
     prop = a ^ b
-    assert(len(prop) == len(gen))
+    assert len(prop) == len(gen)
 
     carry = [gen[0] | prop[0] & cin]
     sum_bit = prop[0] ^ cin

--- a/pyrtl/rtllib/matrix.py
+++ b/pyrtl/rtllib/matrix.py
@@ -736,7 +736,7 @@ class Matrix(object):
             col = mat_ix % self.columns
             self[row, col] = get_value(v_ix)
 
-    def reshape(self, *newshape, order='C'):
+    def reshape(self, *newshape, **order):
         ''' Create a matrix of the given shape from the current matrix.
 
         :param int/ints/tuple[int] newshape: shape of the matrix to return;
@@ -767,6 +767,9 @@ class Matrix(object):
             matrix.reshape(-1, 2) == [[0, 1], [2, 3], [4, 5], [6, 7]]
             matrix.reshape(4, -1) == [[0, 1], [2, 3], [4, 5], [6, 7]]
         '''
+        # python2 does not support named arguments after *args, so we use
+        # **kwargs for 'order' and set the default here.
+        order = order.get('order', 'C')
         count = self.rows * self.columns
         if isinstance(newshape, int):
             if newshape == -1:

--- a/pyrtl/rtllib/multipliers.py
+++ b/pyrtl/rtllib/multipliers.py
@@ -110,9 +110,9 @@ def _one_cycle_mult(areg, breg, rem_bits, sum_sf=0, curr_bit=0):
     else:
         a_curr_val = areg[curr_bit].sign_extended(len(breg))
         if curr_bit == 0:  # if no shift
-            return(_one_cycle_mult(areg, breg, rem_bits - 1,  # areg, breg, rem_bits
-                                   sum_sf + (a_curr_val & breg),  # sum_sf
-                                   curr_bit + 1))  # curr_bit
+            return (_one_cycle_mult(areg, breg, rem_bits - 1,  # areg, breg, rem_bits
+                                    sum_sf + (a_curr_val & breg),  # sum_sf
+                                    curr_bit + 1))  # curr_bit
         else:
             return _one_cycle_mult(
                 areg, breg, rem_bits - 1,  # areg, breg, rem_bits

--- a/pyrtl/rtllib/muxes.py
+++ b/pyrtl/rtllib/muxes.py
@@ -199,5 +199,5 @@ def demux(select):
 
 
 def _demux_2(select):
-    assert(len(select) == 1)
+    assert len(select) == 1
     return ~select, select

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1,6 +1,6 @@
 """Classes for executing and tracing circuit simulations."""
 
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
 
 import sys
 import re

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -369,13 +369,15 @@ digraph g {
     from .importexport import _natural_sort_key
 
     def _node_sort_key(node):
+        # If a LogicNet and a wire share the same name, we want the LogicNet
+        # to sort first, so we arbitrarily 'A' and 'B' suffixes to break ties.
         if isinstance(node, LogicNet):
             if node.op == '@':
-                key = str(node.args[2])
+                key = str(node.args[2]) + 'A'
             else:
-                key = node.dests[0].name
+                key = node.dests[0].name + 'A'
         else:
-            key = node.name
+            key = node.name + 'B'
         return _natural_sort_key(key)
 
     # print the list of nodes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pep8
 pylint
 astroid
-sphinx~=3.5
+sphinx
 sphinx_rtd_theme
 sphinx-hoverxref
 nose

--- a/tests/rtllib/test_muxes.py
+++ b/tests/rtllib/test_muxes.py
@@ -36,7 +36,7 @@ class TestPrioritizedMuxTrivial(unittest.TestCase):
 
 def pri_mux_actual(sels, vals):
     # python version of the pri mux hardware
-    assert(len(sels) == len(vals))
+    assert len(sels) == len(vals)
     for index, s in enumerate(sels):
         if s:
             return vals[index]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, unicode_literals, absolute_import
+from __future__ import print_function, absolute_import
 
 import unittest
 import io

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -1,6 +1,7 @@
 import unittest
 import pyrtl
 import io
+import six
 
 
 class TestConditional(unittest.TestCase):
@@ -12,7 +13,7 @@ class TestConditional(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = io.StringIO()
+        output = six.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -198,7 +199,7 @@ class TestMemConditionalBlock(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = io.StringIO()
+        output = six.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -270,7 +271,7 @@ class TestWireConditionalBlock(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = io.StringIO()
+        output = six.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 
@@ -388,7 +389,7 @@ class TestNonExclusiveBlocks(unittest.TestCase):
         sim = pyrtl.Simulation(tracer=sim_trace)
         for i in range(8):
             sim.step({})
-        output = io.StringIO()
+        output = six.StringIO()
         sim_trace.print_trace(output, compact=True)
         self.assertEqual(output.getvalue(), correct_string)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -122,7 +122,7 @@ class TestSanityCheckNet(unittest.TestCase):
         pyrtl.reset_working_block()
 
     def invalid_net(self, exp_message, *args):
-        with self.assertRaisesRegex(pyrtl.PyrtlInternalError, exp_message):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlInternalError, exp_message):
             pyrtl.working_block().add_net(*args)
 
     @staticmethod
@@ -477,7 +477,7 @@ class TestSanityCheck(unittest.TestCase):
         pyrtl.reset_working_block()
 
     def sanity_error(self, msg, error_type=pyrtl.PyrtlError):
-        with self.assertRaisesRegex(error_type, msg):
+        with six.assertRaisesRegex(self, error_type, msg):
             pyrtl.working_block().sanity_check()
 
     def test_missing_bitwidth(self):

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -591,7 +591,7 @@ class TestInputFromBlif(unittest.TestCase):
         .end
         """
 
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "Off-set found"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "Off-set found"):
             pyrtl.input_from_blif(zeroes_in_offset)
 
     def test_blif_error_bad_coverset(self):
@@ -603,7 +603,7 @@ class TestInputFromBlif(unittest.TestCase):
         10 1 1
         .end
         """
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "malformed cover set"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "malformed cover set"):
             pyrtl.input_from_blif(bad_coverset)
 
     def test_blif_not_gate_correct(self):
@@ -1658,13 +1658,14 @@ class TestVerilogOutput(unittest.TestCase):
 
     def test_error_invalid_add_reset(self):
         buffer = io.StringIO()
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "Invalid add_reset option"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "Invalid add_reset option"):
             pyrtl.output_to_verilog(buffer, add_reset='foobar')
 
     def test_error_existing_reset_wire(self):
         buffer = io.StringIO()
         _rst = pyrtl.Input(1, 'rst')
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "Found a user-defined wire named 'rst'."):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError,
+                                   "Found a user-defined wire named 'rst'."):
             pyrtl.output_to_verilog(buffer)
 
     def test_existing_reset_wire_without_add_reset(self):
@@ -1756,8 +1757,8 @@ class TestVerilogInput(unittest.TestCase):
         self.assertEqual(sim.tracer.trace['o'], [0, 2, 0, 2, 0])
 
     def test_error_import_bad_file(self):
-        with self.assertRaisesRegex(pyrtl.PyrtlError,
-                                    "input_from_verilog expecting either open file or string"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError,
+                                   "input_from_verilog expecting either open file or string"):
             pyrtl.input_from_verilog(3)
 
 
@@ -1955,13 +1956,14 @@ class TestOutputTestbench(unittest.TestCase):
 
     def test_error_verilog_testbench_invalid_add_reset(self):
         tbfile = io.StringIO()
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "Invalid add_reset option"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "Invalid add_reset option"):
             pyrtl.output_verilog_testbench(tbfile, add_reset='foobar')
 
     def test_error_verilog_testbench_existing_reset_wire(self):
         tbfile = io.StringIO()
         _rst = pyrtl.Input(1, 'rst')
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "Found a user-defined wire named 'rst'."):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError,
+                                   "Found a user-defined wire named 'rst'."):
             pyrtl.output_verilog_testbench(tbfile)
 
     def test_verilog_testbench_existing_reset_wire_without_add_reset(self):

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, unicode_literals, absolute_import
+from __future__ import print_function, absolute_import
 
 import unittest
 import six

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -143,7 +143,7 @@ class RenderTraceBase(unittest.TestCase):
             'b': [2, 23, 43, 120, 0],
             'c': [0, 1, 1, 0, 1]
         })
-        buff = io.StringIO()
+        buff = six.StringIO()
         sim.tracer.render_trace(file=buff, render_cls=pyrtl.simulation.AsciiWaveRenderer,
                                 extra_line=False, **kwargs)
         self.assertEqual(buff.getvalue(), expected)
@@ -164,7 +164,13 @@ class RenderTraceBase(unittest.TestCase):
             "b 0o2   x0o27 x0o53 x0o170x0o0  \n"
             "c ______/-----------\\_____/-----\n"  # escaped backslash
         )
-        self.check_rendered_trace(expected, repr_func=oct, symbol_len=None)
+
+        # The oct() builtin prints leading '0o' in python3 but not in python2,
+        # so we define our own.
+        def my_oct(n):
+            return '0o{0:o}'.format(n)
+
+        self.check_rendered_trace(expected, repr_func=my_oct, symbol_len=None)
 
     def test_bin_trace(self):
         expected = (
@@ -173,7 +179,13 @@ class RenderTraceBase(unittest.TestCase):
             "b 0b10      x0b10111  x0b101011 x0b1111000x0b0      \n"
             "c __________/-------------------\\_________/---------\n"  # escaped backslash
         )
-        self.check_rendered_trace(expected, repr_func=bin, symbol_len=None)
+
+        # The bin() builtin prints leading '0b' in python3 but not in python2,
+        # so we define our own.
+        def my_bin(n):
+            return '0b{0:b}'.format(n)
+
+        self.check_rendered_trace(expected, repr_func=my_bin, symbol_len=None)
 
     def test_decimal_trace(self):
         expected = (
@@ -217,7 +229,7 @@ class RenderTraceCustomBase(unittest.TestCase):
         sim.step_multiple({
             'i': [1, 2, 4, 8, 0]
         })
-        buff = io.StringIO()
+        buff = six.StringIO()
         sim.tracer.render_trace(file=buff, render_cls=pyrtl.simulation.AsciiWaveRenderer,
                                 extra_line=None, repr_per_name={'state': Foo}, symbol_len=None)
         expected = (

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -237,11 +237,11 @@ class TestRegister(unittest.TestCase):
         self.assertEqual(r.reset_value, 1)
 
     def test_invalid_reset_value_too_large(self):
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "cannot fit in the specified"):
             r = pyrtl.Register(4, reset_value=16)
 
     def test_invalid_reset_value_too_large_as_string(self):
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+        with six.assertRaisesRegex(self, pyrtl.PyrtlError, "cannot fit in the specified"):
             r = pyrtl.Register(4, reset_value="5'd16")
 
     def test_invalid_reset_value_not_an_integer(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,6 @@ python =
     3.7: py37, pycodestyle
 
 [testenv]
-basepython = python3
-
 deps = test: -rrequirements.txt
        pycodestyle: pycodestyle
        travis: codecov


### PR DESCRIPTION
- Various python 2/3 compatibility issues
- _node_sort_keys were unstable when a wire and an output had the same name
- Remove unnecessary sphinx version constraint (unsatisfiable under python2)
- Remove basepython constraint to avoid a warning (tox will now use the same version of python to set up the test environment and run the tests)
- Clean up pylint errors

`tox` passes with these changes on my system, hopefully these will also fix the github pull request checks.

```
$ uname
CYGWIN_NT-10.0-19043
$ tox -p
GLOB sdist-make: /usr/local/home/lauj/pyrtl/setup.py
✔ OK pycodestyle in 9.774 seconds
✔ OK py27-test in 1 minute, 52.48 seconds
✔ OK py37-test in 5 minutes, 50.654 seconds
  py37-test: commands succeeded
  py27-test: commands succeeded
  pycodestyle: commands succeeded
  congratulations :)
```