### PR TITLE
Add print_perf_counters(), which prints the number of cycles where selected trace values are one.

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1674,3 +1674,32 @@ class SimulationTrace(object):
         self.default_value = default_value
         self.init_regvalue = init_regvalue
         self.init_memvalue = init_memvalue
+
+    def print_perf_counters(self, *trace_names, file=sys.stdout):
+        """Print performance counter statistics for `trace_names`.
+
+        :param str trace_names: List of trace names. Each trace must be a
+            single-bit wire.
+        :param file: The place to write output, defaults to stdout.
+
+        This function prints the number of cycles where each trace's value is
+        one. This is useful for counting the number of times important events
+        occur in a simulation, such as cache misses and branch mispredictions.
+
+        """
+        name_values = []
+        for trace_name in trace_names:
+            wire_length = len(self._wires[trace_name])
+            if wire_length != 1:
+                raise PyrtlError(
+                    'print_perf_counters can only be used with single-bit '
+                    f'wires but wire {trace_name} has bitwidth {wire_length}')
+
+            name_values.append([trace_name, str(sum(self.trace[trace_name]))])
+
+        max_name_length = max(len(name) for name, value in name_values)
+        max_value_length = max(len(value) for name, value in name_values)
+        for name, value in name_values:
+            print(name.rjust(max_name_length),
+                  value.rjust(max_value_length),
+                  file=file)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -345,6 +345,32 @@ class PrintTraceBase(unittest.TestCase):
         self.assertEqual(output.getvalue(), correct_outp)
 
 
+class PrintPerfCountersBase(unittest.TestCase):
+    def setUp(self):
+        pyrtl.reset_working_block()
+        self.a = pyrtl.Input(bitwidth=1, name='a')
+        self.b = pyrtl.Input(bitwidth=1, name='b')
+        self.c = pyrtl.Input(bitwidth=1, name='c')
+
+    def test_print_perf_counters(self):
+        sim_trace = pyrtl.SimulationTrace()
+        sim = self.sim(tracer=sim_trace)
+        for i in range(16):
+            sim.step({
+                self.a: i % 2 == 0,
+                self.b: i % 4 == 0,
+                self.c: i % 8 == 0,
+            })
+        output = six.StringIO()
+        sim_trace.print_perf_counters('a', 'b', 'c', file=output)
+        # a is high for 8 cycles.
+        self.assertTrue('8' in output.getvalue())
+        # b is high for 4 cycles.
+        self.assertTrue('4' in output.getvalue())
+        # c is high for 2 cycles.
+        self.assertTrue('2' in output.getvalue())
+
+
 class SimWithSpecialWiresBase(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()


### PR DESCRIPTION
This is useful for counting the number of times important events occur during a simulation, such as cache misses and branch mispredictions.