### PR TITLE
@wire_struct and wire_matrix help with naming WireVector slices

### DIFF
--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -18,6 +18,8 @@ addition and multiplication).
 .. autofunction:: pyrtl.corecircuits.match_bitwidth
 .. autofunction:: pyrtl.helperfuncs.truncate
 .. autofunction:: pyrtl.helperfuncs.chop
+.. autofunction:: pyrtl.helperfuncs.wire_struct
+.. autofunction:: pyrtl.helperfuncs.wire_matrix
 
 Coercion to WireVector
 ----------------------

--- a/pyrtl/__init__.py
+++ b/pyrtl/__init__.py
@@ -38,6 +38,8 @@ from .helperfuncs import rtl_assert
 from .helperfuncs import check_rtl_assertions
 from .helperfuncs import find_loop
 from .helperfuncs import find_and_print_loop
+from .helperfuncs import wire_struct
+from .helperfuncs import wire_matrix
 
 from .corecircuits import and_all_bits
 from .corecircuits import or_all_bits

--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -5,7 +5,7 @@ import math
 
 from .pyrtlexceptions import PyrtlError, PyrtlInternalError
 from .core import LogicNet, working_block
-from .wire import Const, WireVector
+from .wire import Const, WireVector, WrappedWireVector
 from pyrtl.rtllib import barrel
 from pyrtl.rtllib import muxes
 from .conditional import otherwise
@@ -405,6 +405,8 @@ def as_wires(val, bitwidth=None, truncating=True, block=None):
         # convert to a memory read when the value is actually used
         if val.wire is None:
             val.wire = as_wires(val.mem._readaccess(val.index), bitwidth, truncating, block)
+        return val.wire
+    elif isinstance(val, WrappedWireVector):
         return val.wire
     elif not isinstance(val, WireVector):
         raise PyrtlError('error, expecting a wirevector, int, or verilog-style '


### PR DESCRIPTION
```
@wire_struct
class Byte:
    high: 4  # high is the four most significant bits.
    low: 4   # low is the four least significant bits.
```
This `Byte` `@wire_struct` can be instantiated two ways, by providing a value for each component:
```
  byte = Byte(high=0xA, low=0xB)
```
or by providing a value for the entire `Byte`:
```
  byte = Byte(Byte=0xAB)
```
After construction, `byte` is a `WireVector` representing the entire `Byte` (all 8 wires), `byte.high` is a `WireVector` representing the 4 most significant bits, and `byte.low` is a `WireVector` representing the 4 least significant bits.

`wire_matrix` is similar to `@wire_struct`, except that the slices are numbered instead of named, and all slices must share the same type:

```
# Four slices, each slice has bitwidth 8.
Word = wire_matrix(component_schema=8, size=4)
w = Word(values=[0x89ABCDEF])
print(w[0].bitwidth)  # Prints 8.
```
`@wire_struct` and `wire_matrix` can be composed arbitrarily, so you can have a two-dimensional array of `Bytes` for example.

`@wire_struct` and `wire_matrix` have additional features. See the documentation for details.