### PR TITLE
Eliminate double inverts in pyrtl.optimize

### DIFF
--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -52,14 +52,25 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
         constant_propagation(block, True)
         _remove_unlistened_nets(block)
         common_subexp_elimination(block)
-        _remove_inverter_chains(block, skip_sanity_check)
+        _optimize_inverter_chains(block, skip_sanity_check)
         if (not skip_sanity_check) or _get_debug_mode():
             block.sanity_check()
     return block
 
 
 def _get_inverter_chains(wire_creator, wire_users):
-    """Returns all inverter chains in the block"""
+    """Returns all inverter chains in the block.
+
+    The function returns a list of inverter chains in the block.
+    Each inverter chain is represented as a list of the LogicNets
+    in the chain.
+
+    Consider the following circuit, for example:
+    A -~-> B -~-> C -w-> X
+    D -~-> E -w-> Y
+    If the function is called on this circuit, it will return
+    [[A, B, C], [D, E]].
+    """
 
     # Build a list of inverter chains. Each inverter chain is a list of WireVectors,
     # from source to destination.
@@ -116,8 +127,8 @@ def _get_inverter_chains(wire_creator, wire_users):
     return inverter_chains
 
 
-def _remove_inverter_chains(block, skip_sanity_check=False):
-    """ Removes all inverter chains from the block.
+def _optimize_inverter_chains(block, skip_sanity_check=False):
+    """ Optimizes inverter chains in the block.
 
     An inverter chain means two or more inverters directly connected
     to each other. Inverter chains are redundant and can be removed.
@@ -155,9 +166,9 @@ def _remove_inverter_chains(block, skip_sanity_check=False):
     # This is the optimized version of the circuit:
     # A -w-> X
     # A -w-> Y
-    # The inverter chains found will be B-C and D-E (two separate chains will be
-    # found instead of B-C-D-E because C has an intermediate user). In the dict,
-    # C will be mapped to A and E will be maped to C. Hence, when finding the
+    # The inverter chains found will be A-B-C and C-D-E (two separate chains will be
+    # found instead of A-B-C-D-E because C has an intermediate user). In the dict,
+    # C will be mapped to A and E will be mapped to C. Hence, when finding the
     # replacement of E, we have to first query the dict to get C, and then query
     # the dict again on C to get A.
     wire_src_dict = _ProducerList()
@@ -179,9 +190,9 @@ def _remove_inverter_chains(block, skip_sanity_check=False):
             # Map the end wire of the inverter chain to the beginning wire.
             wire_src_dict[inverter_chain[-1]] = inverter_chain[start_idx - 1]
 
-    # This loop recreates the LogicNet with inverter chains removed. It adds each
-    # block in the original LogicNet to the new LogicNet if it is not marked for
-    # removal, and replaces the source of the block if its source was the end wire
+    # This loop recreates the block with inverter chains removed. It adds each
+    # LogicNet in the original block to the new block if it is not marked for
+    # removal, and replaces the source of the LocigNet if its source was the end wire
     # of a removed inverter chain.
     for net in block.logic:
         if net not in net_removal_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -61,35 +61,81 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
 def _remove_double_inverts(block, skip_sanity_check=False):
     """ Removes all double invert nets from the block. """
 
-    # checks if the wirevector is used at a LogicNet other than used_at_nets
-    def is_wirevector_used_elsewhere(wire, used_at_nets):
-        for net in block:
-            if net not in used_at_nets:
-                if wire.name in [x.name for x in net.args] \
-                        or wire.name in [x.name for x in net.dests]:
-                    return True
-        return False
+    # wire_creator maps from WireVector to the LogicNet that defines its value.
+    # wire_users maps from WireVector to a list of LogicNets that use its value.
+    wire_creator, wire_users = block.net_connections()
+
+    # Build a list of inverter chains. Each inverter chain is a list of WireVectors,
+    # from source to destination.
+    inverter_wirenet_chains = []
+    for current_dest, current_creator in wire_creator.items():
+        if current_creator.op != "~":
+            # Skip non-inverters.
+            continue
+
+        # The current inverter connects current_arg (a WireVector) to current_dest (also
+        # a WireVector).
+        current_arg = current_creator.args[0]
+        # current_users is the number of LogicNets that use current_dest.
+        current_users = len(wire_users[current_dest])
+
+        # Add the current inverter to the end of this inverter chain.
+        append_to = None
+        # Add the current inverter to the beginning of this inverter chain.
+        prepend_to = None
+        next_inverter_chains = []
+        for inverter_wirenet_chain in inverter_wirenet_chains:
+            chain_arg = inverter_wirenet_chain[0]
+            chain_dest = inverter_wirenet_chain[-1]
+            chain_users = len(wire_users[chain_dest])
+
+            if chain_dest is current_arg and chain_users == 1:
+                # This chain's only destination is the current inverter. Append the
+                # current inverter to the chain.
+                append_to = inverter_wirenet_chain
+            elif chain_arg is current_dest and current_users <= 1:
+                # This chain's only argument is the current inverter. Add the current
+                # inverter to the beginning of the chain.
+                prepend_to = inverter_wirenet_chain
+            else:
+                next_inverter_chains.append(inverter_wirenet_chain)
+
+        #print("current inverter: ", current_arg, "->", current_dest)
+        if append_to and prepend_to:
+            # The current inverter joins two existing inverter chains.
+            next_inverter_chains.append(append_to + prepend_to)
+            #print("  joined", next_inverter_chains)
+        elif append_to:
+            # Add the current inverter after 'append_to'.
+            next_inverter_chains.append(append_to + [current_dest])
+            #print("  appended", next_inverter_chains)
+        elif prepend_to:
+            # Add the current inverter before 'prepend_to'.
+            next_inverter_chains.append([current_arg] + prepend_to)
+            #print("  prepended", next_inverter_chains)
+        else:
+            next_inverter_chains.append([current_arg, current_dest])
+            #print("  start new chain", next_inverter_chains)
+
+        inverter_wirenet_chains = next_inverter_chains
 
     new_logic = set()
     net_exclude_set = set()  # removed nets
     wire_removal_set = set()
-    # Dictionary, key is the destination wire of the invert net, value is the invert net
-    invert_destination_wires = {}
-    for net in block:
-        if net.op == "~":
-            invert_destination_wires[net.dests[0].name] = net
+    for inverter_wirenet_chain in inverter_wirenet_chains:
+        if len(inverter_wirenet_chain) > 1:
+            if len(inverter_wirenet_chain) % 2 == 1: # even number of inverters in a chain
+                end_idx = len(inverter_wirenet_chain) - 1
+            else: # odd number of inverters in a chain
+                end_idx = len(inverter_wirenet_chain) - 2
+            wires_to_remove = inverter_wirenet_chain[1:end_idx]
+            new_logic.add(LogicNet('w', None, args=(inverter_wirenet_chain[0],), \
+                                    dests=(inverter_wirenet_chain[end_idx],)))
+            inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
+            inverters_to_remove.add(wire_creator[inverter_wirenet_chain[end_idx]])
 
-    for net in invert_destination_wires.values():
-        # If the argument of the net is in invert_destination_wires, then it is a double invert
-        # If the net is in net_exclude_set, then it was already removed, so we do not process it
-        if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
-            previous_net = invert_destination_wires[net.args[0].name]
-            if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
-                    and previous_net not in net_exclude_set:
-                new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
-                wire_removal_set.add(net.args[0])
-                net_exclude_set.add(net)
-                net_exclude_set.add(previous_net)
+        wire_removal_set.update(wires_to_remove)
+        net_exclude_set.update(inverters_to_remove)
 
     for net in block.logic:
         if net not in net_exclude_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -136,9 +136,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             else:  # odd number of inverters in a chain
                 end_idx = len(inverter_chain) - 2
             wires_to_remove = inverter_chain[1:end_idx+1]
-            for chain_dest in wire_users[inverter_chain[end_idx]]:
-                for arg in chain_dest.args:
-                    wire_src_dict[arg] = inverter_chain[0]
+            wire_src_dict[inverter_chain[end_idx]] = inverter_chain[0]
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
             wire_removal_set.update(wires_to_remove)

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -67,7 +67,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
 
     # Build a list of inverter chains. Each inverter chain is a list of WireVectors,
     # from source to destination.
-    inverter_wirenet_chains = []
+    inverter_chains = []
     for current_dest, current_creator in wire_creator.items():
         if current_creator.op != "~":
             # Skip non-inverters.
@@ -84,61 +84,55 @@ def _remove_double_inverts(block, skip_sanity_check=False):
         # Add the current inverter to the beginning of this inverter chain.
         prepend_to = None
         next_inverter_chains = []
-        for inverter_wirenet_chain in inverter_wirenet_chains:
-            chain_arg = inverter_wirenet_chain[0]
-            chain_dest = inverter_wirenet_chain[-1]
+        for inverter_chain in inverter_chains:
+            chain_arg = inverter_chain[0]
+            chain_dest = inverter_chain[-1]
             chain_users = len(wire_users[chain_dest])
 
             if chain_dest is current_arg and chain_users == 1:
                 # This chain's only destination is the current inverter. Append the
                 # current inverter to the chain.
-                append_to = inverter_wirenet_chain
+                append_to = inverter_chain
             elif chain_arg is current_dest and current_users <= 1:
                 # This chain's only argument is the current inverter. Add the current
                 # inverter to the beginning of the chain.
-                prepend_to = inverter_wirenet_chain
+                prepend_to = inverter_chain
             else:
-                next_inverter_chains.append(inverter_wirenet_chain)
+                next_inverter_chains.append(inverter_chain)
 
-        #print("current inverter: ", current_arg, "->", current_dest)
         if append_to and prepend_to:
             # The current inverter joins two existing inverter chains.
             next_inverter_chains.append(append_to + prepend_to)
-            #print("  joined", next_inverter_chains)
         elif append_to:
             # Add the current inverter after 'append_to'.
             next_inverter_chains.append(append_to + [current_dest])
-            #print("  appended", next_inverter_chains)
         elif prepend_to:
             # Add the current inverter before 'prepend_to'.
             next_inverter_chains.append([current_arg] + prepend_to)
-            #print("  prepended", next_inverter_chains)
         else:
             next_inverter_chains.append([current_arg, current_dest])
-            #print("  start new chain", next_inverter_chains)
 
-        inverter_wirenet_chains = next_inverter_chains
+        inverter_chains = next_inverter_chains
 
     new_logic = set()
-    net_exclude_set = set()  # removed nets
+    net_removal_set = set()
     wire_removal_set = set()
-    for inverter_wirenet_chain in inverter_wirenet_chains:
-        if len(inverter_wirenet_chain) > 2:
-            if len(inverter_wirenet_chain) % 2 == 1: # even number of inverters in a chain
-                end_idx = len(inverter_wirenet_chain) - 1
-            else: # odd number of inverters in a chain
-                end_idx = len(inverter_wirenet_chain) - 2
-            wires_to_remove = inverter_wirenet_chain[1:end_idx]
-            new_logic.add(LogicNet('w', None, args=(inverter_wirenet_chain[0],), \
-                                    dests=(inverter_wirenet_chain[end_idx],)))
+    for inverter_chain in inverter_chains:
+        if len(inverter_chain) > 2:
+            if len(inverter_chain) % 2 == 1:  # even number of inverters in a chain
+                end_idx = len(inverter_chain) - 1
+            else:  # odd number of inverters in a chain
+                end_idx = len(inverter_chain) - 2
+            wires_to_remove = inverter_chain[1:end_idx]
+            new_logic.add(LogicNet('w', None, args=(inverter_chain[0],),
+                                   dests=(inverter_chain[end_idx],)))
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
-            inverters_to_remove.add(wire_creator[inverter_wirenet_chain[end_idx]])
-
+            inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
             wire_removal_set.update(wires_to_remove)
-            net_exclude_set.update(inverters_to_remove)
+            net_removal_set.update(inverters_to_remove)
 
     for net in block.logic:
-        if net not in net_exclude_set:
+        if net not in net_removal_set:
             new_logic.add(net)
 
     block.logic = new_logic

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -140,7 +140,6 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             wire_removal_set.update(wires_to_remove)
             # remove inverters used in the chain
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
-            inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
             net_removal_set.update(inverters_to_remove)
             # map the end wire of the inverter chain to the beginning wire
             wire_src_dict[inverter_chain[end_idx]] = inverter_chain[0]

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -58,12 +58,8 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
     return block
 
 
-def _remove_double_inverts(block, skip_sanity_check=False):
-    """ Removes all double invert nets from the block. """
-
-    # wire_creator maps from WireVector to the LogicNet that defines its value.
-    # wire_users maps from WireVector to a list of LogicNets that use its value.
-    wire_creator, wire_users = block.net_connections()
+def _get_inverter_chains(wire_creator, wire_users):
+    """Returns all inverter chains in the block"""
 
     # Build a list of inverter chains. Each inverter chain is a list of WireVectors,
     # from source to destination.
@@ -93,11 +89,13 @@ def _remove_double_inverts(block, skip_sanity_check=False):
                 # This chain's only destination is the current inverter. Append the
                 # current inverter to the chain.
                 append_to = inverter_chain
-            elif chain_arg is current_dest and current_users <= 1:
+            elif chain_arg is current_dest and current_users == 1:
                 # This chain's only argument is the current inverter. Add the current
                 # inverter to the beginning of the chain.
                 prepend_to = inverter_chain
             else:
+                # The current inverter is not connected to the inverter chain, so we
+                # pass the inverter chain through to next_inverter_chains
                 next_inverter_chains.append(inverter_chain)
 
         if append_to and prepend_to:
@@ -110,14 +108,27 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             # Add the current inverter before 'prepend_to'.
             next_inverter_chains.append([current_arg] + prepend_to)
         else:
+            # The current inverter is not connected to any inverter chain, so
+            # we start a new inverter chain with it
             next_inverter_chains.append([current_arg, current_dest])
 
         inverter_chains = next_inverter_chains
+    return inverter_chains
+
+
+def _remove_double_inverts(block, skip_sanity_check=False):
+    """ Removes all double invert nets from the block. """
+
+    # wire_creator maps from WireVector to the LogicNet that defines its value.
+    # wire_users maps from WireVector to a list of LogicNets that use its value.
+    wire_creator, wire_users = block.net_connections()
 
     new_logic = set()
     net_removal_set = set()
     wire_removal_set = set()
-    for inverter_chain in inverter_chains:
+    for inverter_chain in _get_inverter_chains(wire_creator, wire_users):
+        # if len(inverter_chain) = n, there are n-1 inverters in the chain
+        # only remove inverters if there are at least two inverters in a chain
         if len(inverter_chain) > 2:
             if len(inverter_chain) % 2 == 1:  # even number of inverters in a chain
                 end_idx = len(inverter_chain) - 1

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -52,7 +52,7 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
         constant_propagation(block, True)
         _remove_unlistened_nets(block)
         common_subexp_elimination(block)
-        _remove_double_inverts(block, skip_sanity_check)
+        _remove_inverter_chains(block, skip_sanity_check)
         if (not skip_sanity_check) or _get_debug_mode():
             block.sanity_check()
     return block
@@ -116,8 +116,22 @@ def _get_inverter_chains(wire_creator, wire_users):
     return inverter_chains
 
 
-def _remove_double_inverts(block, skip_sanity_check=False):
-    """ Removes all double invert nets from the block. """
+def _remove_inverter_chains(block, skip_sanity_check=False):
+    """ Removes all inverter chains from the block.
+
+    An inverter chain means two or more inverters directly connected
+    to each other. Inverter chains are redundant and can be removed.
+    For example, A -~-> B -~-> C -w-> X can be reduced to A -w-> X.
+
+    After optimization, a chain of an even number of inverters will
+    be reduced a direct connection, and a chain of an odd number of
+    inverters will be reduced to one inverter.
+
+    If an inverter chain has intermediate users it won't be removed.
+    For example, the inverter chain in the following circuit won't be removed:
+    A -~-> B -~-> C -w-> X
+    B -w-> Y
+    """
 
     # wire_creator maps from WireVector to the LogicNet that defines its value.
     # wire_users maps from WireVector to a list of LogicNets that use its value.
@@ -126,7 +140,28 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     new_logic = set()
     net_removal_set = set()
     wire_removal_set = set()
+
+    # This ProducerList maps the end wire of an inverter chain to its beginning wire.
+    # We need this because when removing an inverter chain its end wire gets removed,
+    # so we need to replace the source of LogicNets using the end wire of the inverter
+    # chain with the chain's beginning wire.
+    #
+    # We need a ProducerList, rather than a simple dict, because if an inverter chain
+    # of more than two inverters has intermediate users, we may have to query the dict
+    # multiple times to get the replacement for the inverter chain's last wire.
+    # Consider the following circuit, for example:
+    # A -~-> B -~-> C -w-> X
+    # C -~-> D -~-> E -w-> Y
+    # This is the optimized version of the circuit:
+    # A -w-> X
+    # A -w-> Y
+    # The inverter chains found will be B-C and D-E (two separate chains will be
+    # found instead of B-C-D-E because C has an intermediate user). In the dict,
+    # C will be mapped to A and E will be maped to C. Hence, when finding the
+    # replacement of E, we have to first query the dict to get C, and then query
+    # the dict again on C to get A.
     wire_src_dict = _ProducerList()
+
     for inverter_chain in _get_inverter_chains(wire_creator, wire_users):
         # if len(inverter_chain) = n, there are n-1 inverters in the chain
         # only remove inverters if there are at least two inverters in a chain
@@ -142,8 +177,12 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             net_removal_set.update(inverters_to_remove)
             # map the end wire of the inverter chain to the beginning wire
-            wire_src_dict[inverter_chain[-1]] = inverter_chain[start_idx-1]
+            wire_src_dict[inverter_chain[-1]] = inverter_chain[start_idx - 1]
 
+    # This loop recreates the LogicNet with inverter chains removed. It adds each
+    # block in the original LogicNet to the new LogicNet if it is not marked for
+    # removal, and replaces the source of the block if its source was the end wire
+    # of a removed inverter chain.
     for net in block.logic:
         if net not in net_removal_set:
             new_logic.add(LogicNet(net.op, net.op_param,

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -61,7 +61,7 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
 def _remove_double_inverts(block, skip_sanity_check=False):
     """ Removes all double invert nets from the block. """
 
-    # checks if the wirevector is used at a LogicNet other than used_at_net
+    # checks if the wirevector is used at a LogicNet other than used_at_nets
     def is_wirevector_used_elsewhere(wire, used_at_nets):
         for net in block.logic:
             if net not in used_at_nets:
@@ -73,24 +73,22 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     new_logic = set()
     net_exclude_set = set()  # removed nets
     wire_removal_set = set()
-    for net1 in block.logic:
-        for net2 in block.logic:
-            # Conditions need to be satisfied for the nets to be removed:
-            # 1. Both nets should be invert nets
-            # 2. Nets should not be in net_exclude_set (nets that are already removed)
-            # 3. The destination of net1 should be the argument of net2
-            #    (so we know the nets are connected)
-            # 4. The destination of net1 should not be used elsewhere
-            #    (because we can't remove a wire that is used in another net)
-            if net1.op == '~' and net2.op == '~' \
-                and net1 not in net_exclude_set and net2 not in net_exclude_set \
-                    and net1.dests[0].name == net2.args[0].name \
-                    and not is_wirevector_used_elsewhere(net1.dests[0], (net1, net2)):
-                new_logic.add(LogicNet('w', None, args=net1.args, dests=net2.dests))
-                net_exclude_set.add(net1)
-                net_exclude_set.add(net2)
-                wire_removal_set.add(net1.dests[0])
-                break
+    # Dictionary, key is the destination wire of the invert net, value is the invert net
+    invert_destination_wires = {}
+    for net in block.logic:
+        if net.op == "~":
+            invert_destination_wires[net.dests[0].name] = net
+    for net in invert_destination_wires.values():
+        # If the argument of the net is in invert_destination_wires, then it is a double invert
+        # If the net is in net_exclude_set, then it was already removed, so we do not process it
+        if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
+            previous_net = invert_destination_wires[net.args[0].name]
+            if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
+                    and previous_net not in net_exclude_set:
+                new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
+                wire_removal_set.add(net.args[0])
+                net_exclude_set.add(net)
+                net_exclude_set.add(previous_net)
 
     for net in block.logic:
         if net not in net_exclude_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -126,8 +126,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     new_logic = set()
     net_removal_set = set()
     wire_removal_set = set()
-    wire_destinations_replacement = dict()
-    wire_sources_replacement = dict()
+    wire_src_dict = _ProducerList()
     for inverter_chain in _get_inverter_chains(wire_creator, wire_users):
         # if len(inverter_chain) = n, there are n-1 inverters in the chain
         # only remove inverters if there are at least two inverters in a chain
@@ -137,17 +136,9 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             else:  # odd number of inverters in a chain
                 end_idx = len(inverter_chain) - 2
             wires_to_remove = inverter_chain[1:end_idx+1]
-            #if inverter_chain[0] in wire_creator:
-            #    chain_source = wire_creator[inverter_chain[0]]
-            #    new_wire_dests = tuple(dest for dest in chain_source.dests if dest is not inverter_chain[0])
-            #    new_wire_dests += (inverter_chain[end_idx],)
-            #    wire_destinations_replacement[chain_source] = new_wire_dests
             for chain_dest in wire_users[inverter_chain[end_idx]]:
-                new_wire_sources = tuple(arg for arg in chain_dest.args if arg is not inverter_chain[end_idx])
-                new_wire_sources += (inverter_chain[0],)
-                wire_sources_replacement[chain_dest] = new_wire_sources
-            #new_logic.add(LogicNet('w', None, args=(inverter_chain[0],),
-            #                       dests=(inverter_chain[end_idx],)))
+                for arg in chain_dest.args:
+                    wire_src_dict[arg] = inverter_chain[0]
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
             wire_removal_set.update(wires_to_remove)
@@ -155,16 +146,8 @@ def _remove_double_inverts(block, skip_sanity_check=False):
 
     for net in block.logic:
         if net not in net_removal_set:
-            #new_logic.add(net)
-            #continue
-            if net in wire_sources_replacement:
-                new_logic.add(LogicNet(net.op, net.op_param, args=wire_sources_replacement[net],
+            new_logic.add(LogicNet(net.op, net.op_param, args=tuple(wire_src_dict.find_producer(x) for x in net.args),
                                        dests=net.dests))
-            #if net in wire_destinations_replacement:
-            #    new_logic.add(LogicNet(net.op, net.op_param, args=net.args,
-            #                           dests=wire_destinations_replacement[net]))
-            else:
-                new_logic.add(net)
 
     block.logic = new_logic
     for dead_wirevector in wire_removal_set:
@@ -172,9 +155,6 @@ def _remove_double_inverts(block, skip_sanity_check=False):
 
     if (not skip_sanity_check) or _get_debug_mode():
         block.sanity_check()
-
-    # clean up wire nodes
-    #_remove_wire_nets(block, skip_sanity_check)
 
 
 class _ProducerList(object):

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -132,17 +132,17 @@ def _remove_double_inverts(block, skip_sanity_check=False):
         # only remove inverters if there are at least two inverters in a chain
         if len(inverter_chain) > 2:
             if len(inverter_chain) % 2 == 1:  # even number of inverters in a chain
-                end_idx = len(inverter_chain) - 1
+                start_idx = 1
             else:  # odd number of inverters in a chain
-                end_idx = len(inverter_chain) - 2
+                start_idx = 2
             # remove wires used in the inverter chain
-            wires_to_remove = inverter_chain[1:end_idx + 1]
+            wires_to_remove = inverter_chain[start_idx:]
             wire_removal_set.update(wires_to_remove)
             # remove inverters used in the chain
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             net_removal_set.update(inverters_to_remove)
             # map the end wire of the inverter chain to the beginning wire
-            wire_src_dict[inverter_chain[end_idx]] = inverter_chain[0]
+            wire_src_dict[inverter_chain[-1]] = inverter_chain[start_idx-1]
 
     for net in block.logic:
         if net not in net_removal_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -78,17 +78,42 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     for net in block.logic:
         if net.op == "~":
             invert_destination_wires[net.dests[0].name] = net
-    for net in invert_destination_wires.values():
-        # If the argument of the net is in invert_destination_wires, then it is a double invert
-        # If the net is in net_exclude_set, then it was already removed, so we do not process it
-        if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
-            previous_net = invert_destination_wires[net.args[0].name]
-            if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
-                    and previous_net not in net_exclude_set:
-                new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
-                wire_removal_set.add(net.args[0])
-                net_exclude_set.add(net)
-                net_exclude_set.add(previous_net)
+    # If double invert nets are removed randomly, this may leave some double inverts behind.
+    # Example: ~(~(~(~a)))
+    # If we remove the middle two inverts first, we will end up with ~((~a)). These remaining
+    # double inverts won't get removed because they aren't directly connected.
+    # To avoid this, we remove double inverts in a chain sequentially from start to end.
+    # For example, we first remove the two outer inverts from ~(~(~(~a))) to get ~(~a),
+    # and then remove the remaining two inner inverts. To do this, we need iterate through
+    # the invert_destination_wires dictionary multiple times, hence the outer while loop.
+    repeat = True
+    while repeat:
+        repeat = False
+        removed_nets = set()
+        for net in invert_destination_wires.values():
+            # If the argument of the net is in invert_destination_wires, then it is a double invert
+            # If the net is in net_exclude_set, then it was already removed, so we do not process it
+            if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
+                previous_net = invert_destination_wires[net.args[0].name]
+                if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
+                        and previous_net not in net_exclude_set:
+                    # If previous_net is in invert_destination_wires, we have a chain of
+                    # 3 or more double inverts. To make sure we remove double inverts
+                    # in these chains sequentially, we only remove the double invert
+                    # we found if the invert net whose destination is previous_net
+                    # was not removed yet. If it was not yet removed, the for loop
+                    # needs to run again, so we set repeat to True.
+                    if previous_net.args[0].name in invert_destination_wires:
+                        repeat = True
+                    else:
+                        new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
+                        wire_removal_set.add(net.args[0])
+                        removed_nets.add(net)
+                        removed_nets.add(previous_net)
+        # remove removed_nets from invert_destination_wires to optimize the for loop
+        for net in removed_nets:
+            del invert_destination_wires[net.dests[0].name]
+        net_exclude_set.update(removed_nets)
 
     for net in block.logic:
         if net not in net_exclude_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -163,20 +163,20 @@ def _remove_inverter_chains(block, skip_sanity_check=False):
     wire_src_dict = _ProducerList()
 
     for inverter_chain in _get_inverter_chains(wire_creator, wire_users):
-        # if len(inverter_chain) = n, there are n-1 inverters in the chain
-        # only remove inverters if there are at least two inverters in a chain
+        # If len(inverter_chain) = n, there are n-1 inverters in the chain.
+        # We only remove inverters if there are at least two inverters in a chain.
         if len(inverter_chain) > 2:
-            if len(inverter_chain) % 2 == 1:  # even number of inverters in a chain
+            if len(inverter_chain) % 2 == 1:  # There is an even number of inverters in a chain.
                 start_idx = 1
-            else:  # odd number of inverters in a chain
+            else:  # There is an odd number of inverters in a chain.
                 start_idx = 2
-            # remove wires used in the inverter chain
+            # Remove wires used in the inverter chain.
             wires_to_remove = inverter_chain[start_idx:]
             wire_removal_set.update(wires_to_remove)
-            # remove inverters used in the chain
+            # Remove inverters used in the chain.
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             net_removal_set.update(inverters_to_remove)
-            # map the end wire of the inverter chain to the beginning wire
+            # Map the end wire of the inverter chain to the beginning wire.
             wire_src_dict[inverter_chain[-1]] = inverter_chain[start_idx - 1]
 
     # This loop recreates the LogicNet with inverter chains removed. It adds each

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -52,9 +52,59 @@ def optimize(update_working_block=True, block=None, skip_sanity_check=False):
         constant_propagation(block, True)
         _remove_unlistened_nets(block)
         common_subexp_elimination(block)
+        _remove_double_inverts(block, skip_sanity_check)
         if (not skip_sanity_check) or _get_debug_mode():
             block.sanity_check()
     return block
+
+
+def _remove_double_inverts(block, skip_sanity_check=False):
+    """ Removes all double invert nets from the block. """
+
+    # checks if the wirevector is used at a LogicNet other than used_at_net
+    def is_wirevector_used_elsewhere(wire, used_at_nets):
+        for net in block.logic:
+            if net not in used_at_nets:
+                if wire.name in [x.name for x in net.args] \
+                        or wire.name in [x.name for x in net.dests]:
+                    return True
+        return False
+
+    new_logic = set()
+    net_exclude_set = set()  # removed nets
+    wire_removal_set = set()
+    for net1 in block.logic:
+        for net2 in block.logic:
+            # Conditions need to be satisfied for the nets to be removed:
+            # 1. Both nets should be invert nets
+            # 2. Nets should not be in net_exclude_set (nets that are already removed)
+            # 3. The destination of net1 should be the argument of net2
+            #    (so we know the nets are connected)
+            # 4. The destination of net1 should not be used elsewhere
+            #    (because we can't remove a wire that is used in another net)
+            if net1.op == '~' and net2.op == '~' \
+                and net1 not in net_exclude_set and net2 not in net_exclude_set \
+                    and net1.dests[0].name == net2.args[0].name \
+                    and not is_wirevector_used_elsewhere(net1.dests[0], (net1, net2)):
+                new_logic.add(LogicNet('w', None, args=net1.args, dests=net2.dests))
+                net_exclude_set.add(net1)
+                net_exclude_set.add(net2)
+                wire_removal_set.add(net1.dests[0])
+                break
+
+    for net in block.logic:
+        if net not in net_exclude_set:
+            new_logic.add(net)
+
+    block.logic = new_logic
+    for dead_wirevector in wire_removal_set:
+        block.remove_wirevector(dead_wirevector)
+
+    if (not skip_sanity_check) or _get_debug_mode():
+        block.sanity_check()
+
+    # clean up wire nodes
+    _remove_wire_nets(block, skip_sanity_check)
 
 
 class _ProducerList(object):

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -135,17 +135,21 @@ def _remove_double_inverts(block, skip_sanity_check=False):
                 end_idx = len(inverter_chain) - 1
             else:  # odd number of inverters in a chain
                 end_idx = len(inverter_chain) - 2
-            wires_to_remove = inverter_chain[1:end_idx+1]
-            wire_src_dict[inverter_chain[end_idx]] = inverter_chain[0]
+            # remove wires used in the inverter chain
+            wires_to_remove = inverter_chain[1:end_idx + 1]
+            wire_removal_set.update(wires_to_remove)
+            # remove inverters used in the chain
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
-            wire_removal_set.update(wires_to_remove)
             net_removal_set.update(inverters_to_remove)
+            # map the end wire of the inverter chain to the beginning wire
+            wire_src_dict[inverter_chain[end_idx]] = inverter_chain[0]
 
     for net in block.logic:
         if net not in net_removal_set:
-            new_logic.add(LogicNet(net.op, net.op_param, args=tuple(wire_src_dict.find_producer(x) for x in net.args),
-                                       dests=net.dests))
+            new_logic.add(LogicNet(net.op, net.op_param,
+                                   args=tuple(wire_src_dict.find_producer(x) for x in net.args),
+                                   dests=net.dests))
 
     block.logic = new_logic
     for dead_wirevector in wire_removal_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -126,6 +126,8 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     new_logic = set()
     net_removal_set = set()
     wire_removal_set = set()
+    wire_destinations_replacement = dict()
+    wire_sources_replacement = dict()
     for inverter_chain in _get_inverter_chains(wire_creator, wire_users):
         # if len(inverter_chain) = n, there are n-1 inverters in the chain
         # only remove inverters if there are at least two inverters in a chain
@@ -134,9 +136,18 @@ def _remove_double_inverts(block, skip_sanity_check=False):
                 end_idx = len(inverter_chain) - 1
             else:  # odd number of inverters in a chain
                 end_idx = len(inverter_chain) - 2
-            wires_to_remove = inverter_chain[1:end_idx]
-            new_logic.add(LogicNet('w', None, args=(inverter_chain[0],),
-                                   dests=(inverter_chain[end_idx],)))
+            wires_to_remove = inverter_chain[1:end_idx+1]
+            #if inverter_chain[0] in wire_creator:
+            #    chain_source = wire_creator[inverter_chain[0]]
+            #    new_wire_dests = tuple(dest for dest in chain_source.dests if dest is not inverter_chain[0])
+            #    new_wire_dests += (inverter_chain[end_idx],)
+            #    wire_destinations_replacement[chain_source] = new_wire_dests
+            for chain_dest in wire_users[inverter_chain[end_idx]]:
+                new_wire_sources = tuple(arg for arg in chain_dest.args if arg is not inverter_chain[end_idx])
+                new_wire_sources += (inverter_chain[0],)
+                wire_sources_replacement[chain_dest] = new_wire_sources
+            #new_logic.add(LogicNet('w', None, args=(inverter_chain[0],),
+            #                       dests=(inverter_chain[end_idx],)))
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             inverters_to_remove.add(wire_creator[inverter_chain[end_idx]])
             wire_removal_set.update(wires_to_remove)
@@ -144,7 +155,16 @@ def _remove_double_inverts(block, skip_sanity_check=False):
 
     for net in block.logic:
         if net not in net_removal_set:
-            new_logic.add(net)
+            #new_logic.add(net)
+            #continue
+            if net in wire_sources_replacement:
+                new_logic.add(LogicNet(net.op, net.op_param, args=wire_sources_replacement[net],
+                                       dests=net.dests))
+            #if net in wire_destinations_replacement:
+            #    new_logic.add(LogicNet(net.op, net.op_param, args=net.args,
+            #                           dests=wire_destinations_replacement[net]))
+            else:
+                new_logic.add(net)
 
     block.logic = new_logic
     for dead_wirevector in wire_removal_set:
@@ -154,7 +174,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
         block.sanity_check()
 
     # clean up wire nodes
-    _remove_wire_nets(block, skip_sanity_check)
+    #_remove_wire_nets(block, skip_sanity_check)
 
 
 class _ProducerList(object):

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -62,7 +62,7 @@ def _get_inverter_chains(wire_creator, wire_users):
     """Returns all inverter chains in the block.
 
     The function returns a list of inverter chains in the block.
-    Each inverter chain is represented as a list of the LogicNets
+    Each inverter chain is represented as a list of the WireVectors
     in the chain.
 
     Consider the following circuit, for example:
@@ -192,7 +192,7 @@ def _optimize_inverter_chains(block, skip_sanity_check=False):
 
     # This loop recreates the block with inverter chains removed. It adds each
     # LogicNet in the original block to the new block if it is not marked for
-    # removal, and replaces the source of the LocigNet if its source was the end wire
+    # removal, and replaces the source of the LogicNet if its source was the end wire
     # of a removed inverter chain.
     for net in block.logic:
         if net not in net_removal_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -123,7 +123,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     net_exclude_set = set()  # removed nets
     wire_removal_set = set()
     for inverter_wirenet_chain in inverter_wirenet_chains:
-        if len(inverter_wirenet_chain) > 1:
+        if len(inverter_wirenet_chain) > 2:
             if len(inverter_wirenet_chain) % 2 == 1: # even number of inverters in a chain
                 end_idx = len(inverter_wirenet_chain) - 1
             else: # odd number of inverters in a chain
@@ -134,8 +134,8 @@ def _remove_double_inverts(block, skip_sanity_check=False):
             inverters_to_remove = {wire_creator[wire] for wire in wires_to_remove}
             inverters_to_remove.add(wire_creator[inverter_wirenet_chain[end_idx]])
 
-        wire_removal_set.update(wires_to_remove)
-        net_exclude_set.update(inverters_to_remove)
+            wire_removal_set.update(wires_to_remove)
+            net_exclude_set.update(inverters_to_remove)
 
     for net in block.logic:
         if net not in net_exclude_set:

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -63,7 +63,7 @@ def _remove_double_inverts(block, skip_sanity_check=False):
 
     # checks if the wirevector is used at a LogicNet other than used_at_nets
     def is_wirevector_used_elsewhere(wire, used_at_nets):
-        for net in block.logic:
+        for net in block:
             if net not in used_at_nets:
                 if wire.name in [x.name for x in net.args] \
                         or wire.name in [x.name for x in net.dests]:
@@ -75,45 +75,21 @@ def _remove_double_inverts(block, skip_sanity_check=False):
     wire_removal_set = set()
     # Dictionary, key is the destination wire of the invert net, value is the invert net
     invert_destination_wires = {}
-    for net in block.logic:
+    for net in block:
         if net.op == "~":
             invert_destination_wires[net.dests[0].name] = net
-    # If double invert nets are removed randomly, this may leave some double inverts behind.
-    # Example: ~(~(~(~a)))
-    # If we remove the middle two inverts first, we will end up with ~((~a)). These remaining
-    # double inverts won't get removed because they aren't directly connected.
-    # To avoid this, we remove double inverts in a chain sequentially from start to end.
-    # For example, we first remove the two outer inverts from ~(~(~(~a))) to get ~(~a),
-    # and then remove the remaining two inner inverts. To do this, we need iterate through
-    # the invert_destination_wires dictionary multiple times, hence the outer while loop.
-    repeat = True
-    while repeat:
-        repeat = False
-        removed_nets = set()
-        for net in invert_destination_wires.values():
-            # If the argument of the net is in invert_destination_wires, then it is a double invert
-            # If the net is in net_exclude_set, then it was already removed, so we do not process it
-            if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
-                previous_net = invert_destination_wires[net.args[0].name]
-                if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
-                        and previous_net not in net_exclude_set:
-                    # If previous_net is in invert_destination_wires, we have a chain of
-                    # 3 or more double inverts. To make sure we remove double inverts
-                    # in these chains sequentially, we only remove the double invert
-                    # we found if the invert net whose destination is previous_net
-                    # was not removed yet. If it was not yet removed, the for loop
-                    # needs to run again, so we set repeat to True.
-                    if previous_net.args[0].name in invert_destination_wires:
-                        repeat = True
-                    else:
-                        new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
-                        wire_removal_set.add(net.args[0])
-                        removed_nets.add(net)
-                        removed_nets.add(previous_net)
-        # remove removed_nets from invert_destination_wires to optimize the for loop
-        for net in removed_nets:
-            del invert_destination_wires[net.dests[0].name]
-        net_exclude_set.update(removed_nets)
+
+    for net in invert_destination_wires.values():
+        # If the argument of the net is in invert_destination_wires, then it is a double invert
+        # If the net is in net_exclude_set, then it was already removed, so we do not process it
+        if net.args[0].name in invert_destination_wires and net not in net_exclude_set:
+            previous_net = invert_destination_wires[net.args[0].name]
+            if not is_wirevector_used_elsewhere(net.args[0], (net, previous_net)) \
+                    and previous_net not in net_exclude_set:
+                new_logic.add(LogicNet('w', None, args=previous_net.args, dests=net.dests))
+                wire_removal_set.add(net.args[0])
+                net_exclude_set.add(net)
+                net_exclude_set.add(previous_net)
 
     for net in block.logic:
         if net not in net_exclude_set:

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -316,6 +316,87 @@ class TestOptimization(NetWireNumTestCases):
         self.num_net_of_type('s', 1, block)
         self.num_net_of_type('w', 2, block)
 
+    def test_remove_double_inverts_1_invert(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~inwire
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(2, block)
+        self.assert_num_wires(3, block)
+
+    def test_remove_double_inverts_3_inverts(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~(~inwire))
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(2, block)
+        self.assert_num_wires(3, block)
+
+    def test_remove_double_inverts_5_inverts(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~(~(~(~inwire))))
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(2, block)
+        self.assert_num_wires(3, block)
+
+    def test_remove_double_inverts_2_inverts(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~inwire)
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(1, block)
+        self.assert_num_wires(2, block)
+
+    def test_remove_double_inverts_4_inverts(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~(~(~inwire)))
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(1, block)
+        self.assert_num_wires(2, block)
+
+    def test_remove_double_inverts_6_inverts(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~(~(~(~(~inwire)))))
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(1, block)
+        self.assert_num_wires(2, block)
+
+    def test_dont_remove_double_inverts_another_user(self):
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire2 = pyrtl.Output(bitwidth=1)
+        tempwire = pyrtl.WireVector()
+        tempwire <<= ~inwire
+        outwire <<= ~tempwire
+        outwire2 <<= tempwire
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(4, block)
+        self.assert_num_wires(5, block)
+
+    def test_multiple_double_invert_chains(self):
+        # _remove_double_inverts removes double inverts by chains,
+        # so it is useful to make sure it can remove
+        # double inverts from multiple chains
+        inwire = pyrtl.Input(bitwidth=1)
+        outwire = pyrtl.Output(bitwidth=1)
+        outwire2 = pyrtl.Output(bitwidth=1)
+        outwire <<= ~(~inwire)
+        outwire2 <<= ~(~(~(~(inwire))))
+        pyrtl.optimize()
+        block = pyrtl.working_block()
+        self.assert_num_net(2, block)
+        self.assert_num_wires(3, block)
+
 
 class TestConstFolding(NetWireNumTestCases):
     def setUp(self):


### PR DESCRIPTION
Closes #447

Example:

| Block before optimize | Block after optimize (without my changes) | Block after optimize (with my changes) |
| -------- | ------- | ------- |
| <img width="79" alt="image" src="https://github.com/user-attachments/assets/19ad1139-8a32-47fe-a193-69286cce0022" />  | <img width="82" alt="image" src="https://github.com/user-attachments/assets/107bdc15-1249-4a19-9eb2-dd354a467318" /> | <img width="82" alt="image" src="https://github.com/user-attachments/assets/71da9891-d228-4d25-842e-b5b6e6a54302" /> |