### PR TITLE
Remove unneeded exception in memory.py

### DIFF
--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -259,10 +259,7 @@ class MemBlock(object):
     def _assignment(self, item, val, is_conditional):
         from .conditional import _build
 
-        item = as_wires(item, bitwidth=self.addrwidth, truncating=False)
-        if len(item) > self.addrwidth:
-            raise PyrtlError('error, the wire indexing the memory bitwidth > addrwidth')
-        addr = item
+        addr = as_wires(item, bitwidth=self.addrwidth, truncating=False)
 
         if isinstance(val, MemBlock.EnabledWrite):
             data, enable = val.data, val.enable

--- a/pyrtl/memory.py
+++ b/pyrtl/memory.py
@@ -259,6 +259,9 @@ class MemBlock(object):
     def _assignment(self, item, val, is_conditional):
         from .conditional import _build
 
+        # Even though as_wires is already called on item already in the __getitem__ method,
+        # we need to call it again here because __setitem__ passes the original item
+        # to _assignment.
         addr = as_wires(item, bitwidth=self.addrwidth, truncating=False)
 
         if isinstance(val, MemBlock.EnabledWrite):


### PR DESCRIPTION
Closes #460 

The call to `as_wires` is needed in `_assignment`, tests fail without that.