### PR TITLE
Allow negative Register reset values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ ipynb-examples/.ipynb_checkpoints
 
 # VS Code
 .vscode
+
+# Python venv
+pyvenv.cfg

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -804,8 +804,8 @@ def _convert_verilog_str(val: str, bitwidth: int = None,
         if verilog_bitwidth > bitwidth:
             raise PyrtlError(
                 "bitwidth parameter passed (%d) cannot fit Verilog-style constant with bitwidth %d"
-                % (bitwidth, verilog_bitwidth) +
-                " (if bitwidth=None is used, PyRTL will determine the bitwidth from the "
+                % (bitwidth, verilog_bitwidth)
+                + " (if bitwidth=None is used, PyRTL will determine the bitwidth from the "
                 "Verilog-style constant specification)"
             )
 

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -789,7 +789,6 @@ def _convert_verilog_str(val: str, bitwidth: int = None,
         raise PyrtlError('error, "signed" option with verilog-style string constants not supported')
 
     bases = {'b': 2, 'o': 8, 'd': 10, 'h': 16, 'x': 16}
-    passed_bitwidth = bitwidth
 
     neg = False
     if val.startswith('-'):
@@ -800,18 +799,19 @@ def _convert_verilog_str(val: str, bitwidth: int = None,
     if len(split_string) != 2:
         raise PyrtlError('error, string not in verilog style format')
     try:
-        bitwidth = int(split_string[0])
-        if passed_bitwidth is not None:
-            if bitwidth > passed_bitwidth:
-                raise PyrtlError(
-                    "bitwidth parameter passed (%d) cannot fit Verilog-style constant with bitwidth %d"
-                        % (passed_bitwidth, bitwidth)
-                )
-            bitwidth = passed_bitwidth
+        verilog_bitwidth = int(split_string[0])
+        bitwidth = bitwidth or verilog_bitwidth  # if bitwidth is None, use verilog_bitwidth
+        if verilog_bitwidth > bitwidth:
+            raise PyrtlError(
+                "bitwidth parameter passed (%d) cannot fit Verilog-style constant with bitwidth %d"
+                % (bitwidth, verilog_bitwidth) +
+                " (if bitwidth=None is used, PyRTL will determine the bitwidth from the "
+                "Verilog-style constant specification)"
+            )
 
         sval = split_string[1]
         if sval[0] == 's':
-            raise PyrtlError('error, signed integers are not supported in verilog-style constants')
+            raise PyrtlError('error, signed integers are not supported in Verilog-style constants')
         base = 10
         if sval[0] in bases:
             base = bases[sval[0]]

--- a/pyrtl/helperfuncs.py
+++ b/pyrtl/helperfuncs.py
@@ -795,11 +795,20 @@ def _convert_verilog_str(val: str, bitwidth: int = None,
     if val.startswith('-'):
         neg = True
         val = val[1:]
+
     split_string = val.lower().split("'")
     if len(split_string) != 2:
         raise PyrtlError('error, string not in verilog style format')
     try:
         bitwidth = int(split_string[0])
+        if passed_bitwidth is not None:
+            if bitwidth > passed_bitwidth:
+                raise PyrtlError(
+                    "bitwidth parameter passed (%d) cannot fit Verilog-style constant with bitwidth %d"
+                        % (passed_bitwidth, bitwidth)
+                )
+            bitwidth = passed_bitwidth
+
         sval = split_string[1]
         if sval[0] == 's':
             raise PyrtlError('error, signed integers are not supported in verilog-style constants')
@@ -811,16 +820,11 @@ def _convert_verilog_str(val: str, bitwidth: int = None,
         num = int(sval, base)
     except (IndexError, ValueError):
         raise PyrtlError('error, string not in verilog style format')
+
     if neg and num:
         if (num >> bitwidth - 1):
             raise PyrtlError('error, insufficient bits for negative number')
         num = (1 << bitwidth) - num
-
-    if passed_bitwidth and passed_bitwidth != bitwidth:
-        raise PyrtlError('error, bitwidth parameter of constant does not match'
-                         ' the bitwidth infered from the verilog style specification'
-                         ' (if bitwidth=None is used, pyrtl will determine the bitwidth from the'
-                         ' verilog-style constant specification)')
 
     if num >> bitwidth != 0:
         raise PyrtlError('specified bitwidth %d for verilog constant insufficient to store value %d'

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -852,29 +852,15 @@ class Register(WireVector):
         super(Register, self).__init__(bitwidth=bitwidth, name=name, block=block)
         self.reg_in = None  # wire vector setting self.next
         if reset_value is not None:
-            # detect if reset_value is a negative Verilog constant and sign
-            # extend it to the correct bitwidth
-            if isinstance(reset_value, str) and reset_value.startswith('-'):
-                verilog_bitwidth, constant = reset_value[1:].split("'")
-                if int(verilog_bitwidth) > bitwidth:
-                    raise PyrtlError(
-                        'reset_value "%s" cannot fit in the specified %d bits for this register'
-                        % (str(reset_value), bitwidth)
-                    )
-
-                reset_value = '-' + str(bitwidth) + "'" + constant
-
             reset_value, rst_bitwidth = infer_val_and_bitwidth(
                 reset_value,
-                # the below allows for Verilog strings with bitwidths less
-                # than what is specified for the register
-                # e.g. -3'd6 is a valid reset value for a 4-bit register
-                bitwidth=(None if isinstance(reset_value, str) else bitwidth)
+                bitwidth=bitwidth,
             )
             if rst_bitwidth > bitwidth:
                 raise PyrtlError(
                     'reset_value "%s" cannot fit in the specified %d bits for this register'
-                    % (str(reset_value), bitwidth))
+                    % (str(reset_value), bitwidth)
+                )
         self.reset_value = reset_value
 
     @property

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -852,7 +852,8 @@ class Register(WireVector):
         super(Register, self).__init__(bitwidth=bitwidth, name=name, block=block)
         self.reg_in = None  # wire vector setting self.next
         if reset_value is not None:
-            reset_value, rst_bitwidth = infer_val_and_bitwidth(reset_value)
+            # NOTE: pass bitwidth here to allow for negative reset values
+            reset_value, rst_bitwidth = infer_val_and_bitwidth(reset_value, bitwidth=bitwidth)
             if rst_bitwidth > bitwidth:
                 raise PyrtlError(
                     'reset_value "%s" cannot fit in the specified %d bits for this register'

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -852,8 +852,11 @@ class Register(WireVector):
         super(Register, self).__init__(bitwidth=bitwidth, name=name, block=block)
         self.reg_in = None  # wire vector setting self.next
         if reset_value is not None:
-            # NOTE: pass bitwidth here to allow for negative reset values
-            reset_value, rst_bitwidth = infer_val_and_bitwidth(reset_value, bitwidth=bitwidth)
+            # NOTE: passing bitwidth here to allow for negative reset values
+            reset_value, rst_bitwidth = infer_val_and_bitwidth(
+                reset_value,
+                bitwidth=(None if isinstance(reset_value, str) else bitwidth)
+            )
             if rst_bitwidth > bitwidth:
                 raise PyrtlError(
                     'reset_value "%s" cannot fit in the specified %d bits for this register'

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -852,9 +852,23 @@ class Register(WireVector):
         super(Register, self).__init__(bitwidth=bitwidth, name=name, block=block)
         self.reg_in = None  # wire vector setting self.next
         if reset_value is not None:
-            # NOTE: passing bitwidth here to allow for negative reset values
+            # detect if reset_value is a negative Verilog constant and sign
+            # extend it to the correct bitwidth
+            if isinstance(reset_value, str) and reset_value.startswith('-'):
+                verilog_bitwidth, constant = reset_value[1:].split("'")
+                if int(verilog_bitwidth) > bitwidth:
+                    raise PyrtlError(
+                        'reset_value "%s" cannot fit in the specified %d bits for this register'
+                        % (str(reset_value), bitwidth)
+                    )
+
+                reset_value = '-' + str(bitwidth) + "'" + constant
+
             reset_value, rst_bitwidth = infer_val_and_bitwidth(
                 reset_value,
+                # the below allows for Verilog strings with bitwidths less
+                # than what is specified for the register
+                # e.g. -3'd6 is a valid reset value for a 4-bit register
                 bitwidth=(None if isinstance(reset_value, str) else bitwidth)
             )
             if rst_bitwidth > bitwidth:

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -263,12 +263,29 @@ class TestRegister(unittest.TestCase):
         self.assertEqual(r.reset_value, 1)
 
     def test_invalid_reset_value_too_large(self):
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+        with self.assertRaisesRegex(
+            pyrtl.PyrtlError,
+            "bitwidth specified \\(4\\) is insufficient to represent constant 16"
+        ):
             r = pyrtl.Register(4, reset_value=16)
 
     def test_invalid_reset_value_too_large_as_string(self):
         with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
             r = pyrtl.Register(4, reset_value="5'd16")
+
+    def test_negative_reset_value(self):
+        r = pyrtl.Register(4, reset_value=-4)
+        self.assertEqual(
+            pyrtl.helperfuncs.val_to_signed_integer(r.reset_value, r.bitwidth),
+            -4
+        )
+
+    def test_negative_reset_value_as_string(self):
+        r = pyrtl.Register(4, reset_value="-4'd1")
+        self.assertEqual(
+            pyrtl.helperfuncs.val_to_signed_integer(r.reset_value, r.bitwidth),
+            -1
+        )
 
     def test_invalid_reset_value_not_an_integer(self):
         with self.assertRaises(pyrtl.PyrtlError):

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -370,7 +370,6 @@ class TestConst(unittest.TestCase):
         self.assert_bad_const("5'b111111'")
         self.assert_bad_const("'")
         self.assert_bad_const("'1")
-        self.assert_bad_const("2'b01", bitwidth=3)
         self.assert_bad_const("1'")
 
     def test_bool(self):

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -263,14 +263,11 @@ class TestRegister(unittest.TestCase):
         self.assertEqual(r.reset_value, 1)
 
     def test_invalid_reset_value_too_large(self):
-        with self.assertRaisesRegex(
-            pyrtl.PyrtlError,
-            "bitwidth specified \\(4\\) is insufficient to represent constant 16"
-        ):
+        with self.assertRaises(pyrtl.PyrtlError):
             r = pyrtl.Register(4, reset_value=16)
 
     def test_invalid_reset_value_too_large_as_string(self):
-        with self.assertRaisesRegex(pyrtl.PyrtlError, "cannot fit in the specified"):
+        with self.assertRaises(pyrtl.PyrtlError):
             r = pyrtl.Register(4, reset_value="5'd16")
 
     def test_negative_reset_value(self):
@@ -285,6 +282,17 @@ class TestRegister(unittest.TestCase):
         self.assertEqual(
             pyrtl.helperfuncs.val_to_signed_integer(r.reset_value, r.bitwidth),
             -1
+        )
+
+    def test_invalid_negative_reset_value_as_string(self):
+        with self.assertRaises(pyrtl.PyrtlError):
+            r = pyrtl.Register(2, reset_value="-4'd1")
+
+    def test_extending_negative_reset_value_as_string(self):
+        r = pyrtl.Register(4, reset_value="-3'd3")
+        self.assertEqual(
+            pyrtl.helperfuncs.val_to_signed_integer(r.reset_value, r.bitwidth),
+            -3
         )
 
     def test_invalid_reset_value_not_an_integer(self):


### PR DESCRIPTION
Pass bitwidth to `infer_val_and_bitwidth` in Register.__init__ to allow negative Register reset values