### PR TITLE
Use a loop instead of recursion in the find_producer function

### DIFF
--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -70,7 +70,7 @@ class _ProducerList(object):
 
     def find_producer(self, item):
         while item in self.dict:
-            item = self.find_producer(self.dict[item])
+            item = self.dict[item]
         return item
 
 

--- a/pyrtl/passes.py
+++ b/pyrtl/passes.py
@@ -69,10 +69,9 @@ class _ProducerList(object):
         self.dict[key] = item
 
     def find_producer(self, item):
-        if item in self.dict:
-            return self.find_producer(self.dict[item])
-        else:
-            return item
+        while item in self.dict:
+            item = self.find_producer(self.dict[item])
+        return item
 
 
 def _remove_wire_nets(block, skip_sanity_check=False):


### PR DESCRIPTION
I changed the `find_producer` function in `_ProducerList` from a recursive implementation to an iterative one. As far as I know, recursion is not recommended in production code, especially when a simple iterative approach can achieve the same result.