### PR TITLE
Throw an exception if the user tries to render a trace without stepping the simulation

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1755,6 +1755,8 @@ class SimulationTrace:
             is not found in the map, the argument ``repr_func`` will be used instead.
         :param segment_size: Traces are broken in the segments of this number of cycles.
         """
+        if len(self) == 0:
+            raise PyrtlError("You need to step the simulation at least once to render a trace.")
         if repr_per_name is None:
             repr_per_name = {}
         if _currently_in_jupyter_notebook():

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1756,7 +1756,8 @@ class SimulationTrace:
         :param segment_size: Traces are broken in the segments of this number of cycles.
         """
         if len(self) == 0:
-            raise PyrtlError("You need to step the simulation at least once to render a trace.")
+            msg = "You need to step the simulation at least once to render a trace."
+            raise PyrtlError(msg)
         if repr_per_name is None:
             repr_per_name = {}
         if _currently_in_jupyter_notebook():

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -1206,14 +1206,8 @@ class TraceErrorBase(unittest.TestCase):
         r.next <<= r + 1
         sim = self.sim()
         sim.step_multiple(provided_inputs={}, nsteps=10)
-        with self.assertRaises(pyrtl.PyrtlError) as ex:
+        with self.assertRaises(pyrtl.PyrtlError):
             sim.tracer.render_trace()
-        self.assertEqual(
-            str(ex.exception),
-            "Empty trace list. This may have occurred because "
-            "untraceable wires were removed prior to simulation, "
-            "if a CompiledSimulation was used.",
-        )
 
     def test_invalid_base(self):
         self.in1 = pyrtl.Input(8, "in1")


### PR DESCRIPTION
When the user tries to render a trace without stepping the simulation, PyRTL gives this weird error:

```
gabi@Gabors-MacBook-Pro PyRTL % python3 test.py
Traceback (most recent call last):
  File "/Users/gabi/Documents/PyRTL/test.py", line 8, in <module>
    sim.tracer.render_trace()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/gabi/Documents/PyRTL/pyrtl/simulation.py", line 1787, in render_trace
    self.render_trace_to_text(
    ~~~~~~~~~~~~~~~~~~~~~~~~~^
        trace_list=trace_list,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        segment_size=segment_size,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/gabi/Documents/PyRTL/pyrtl/simulation.py", line 1876, in render_trace_to_text
    current_symbol_len = max(
        len(
    ...<4 lines>...
        for v in trace
    )
ValueError: max() iterable argument is empty
```

`test.py`:

```
import pyrtl

a = pyrtl.Register(name="test_reg", bitwidth=3)
a.next <<= a+1

sim = pyrtl.Simulation()

sim.tracer.render_trace()
```

Output after this PR:

```
gabi@Gabors-MacBook-Pro PyRTL % python3 test.py
Traceback (most recent call last):
  File "/Users/gabi/Documents/PyRTL/test.py", line 8, in <module>
    sim.tracer.render_trace()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/gabi/Documents/PyRTL/pyrtl/simulation.py", line 1760, in render_trace
    raise PyrtlError("You need to step the simulation at least once to render a trace.")
pyrtl.pyrtlexceptions.PyrtlError: You need to step the simulation at least once to render a trace.
```

I was working on pyrtlnet and it took me around 10 minutes to figure out why I'm getting this error so I decided to open this little PR 😅