### PR TITLE
Fix Wavedrom in Jupyter Notebook

### DIFF
--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1775,16 +1775,12 @@ class SimulationTrace:
             html_elem = HTML(htmlstring)
             display(html_elem)
             # print(htmlstring)
-            js_stuff = """
-            $.when(
-            $.getScript("https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"),
-            $.getScript("https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"),
-            $.Deferred(function( deferred ){
-                $( deferred.resolve );
-            })).done(function(){
-                WaveDrom.ProcessAll();
-            });"""
-            display(Javascript(js_stuff))
+            html_stuff = """
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"></script>
+            <style onload="WaveDrom.ProcessAll();"></style>
+            """
+            display(HTML(html_stuff))
         else:
             self.render_trace_to_text(
                 trace_list=trace_list,

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1763,23 +1763,31 @@ class SimulationTrace:
         if _currently_in_jupyter_notebook():
             from IPython.display import (
                 HTML,
+                Javascript,
                 display,
             )
 
             from pyrtl.visualization import trace_to_html
 
-            htmlstring = trace_to_html(
-                self, trace_list=trace_list, sortkey=_trace_sort_key
+            display(
+                HTML(
+                    trace_to_html(self, trace_list=trace_list, sortkey=_trace_sort_key)
+                ),
+                HTML("""
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"></script>
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"></script>
+                """),
+                # Wait for WaveDrom to load, polling every 100ms.
+                Javascript("""
+                var interval = setInterval(function() {
+                    if (typeof WaveDrom !== 'undefined' &&
+                        typeof WaveDrom.ProcessAll === 'function') {
+                        clearInterval(interval);
+                        WaveDrom.ProcessAll();
+                    }
+                }, 100);
+                """),
             )
-            html_elem = HTML(htmlstring)
-            display(html_elem)
-            # print(htmlstring)
-            html_stuff = """
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/skins/default.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/wavedrom/1.6.2/wavedrom.min.js"></script>
-            <style onload="WaveDrom.ProcessAll();"></style>
-            """
-            display(HTML(html_stuff))
         else:
             self.render_trace_to_text(
                 trace_list=trace_list,

--- a/pyrtl/simulation.py
+++ b/pyrtl/simulation.py
@@ -1763,7 +1763,6 @@ class SimulationTrace:
         if _currently_in_jupyter_notebook():
             from IPython.display import (
                 HTML,
-                Javascript,
                 display,
             )
 


### PR DESCRIPTION
* Use HTML tags instead of jQuery.
  Tested with Jupyter Notebook 7.5.4.

There may be better solution, anyway please fix the error without jQuery.