### PR TITLE
Remove unnecessary slice (`s`) `LogicNets` from `sign_extended` and `zero_extended`.

### DIFF
--- a/pyrtl/importexport.py
+++ b/pyrtl/importexport.py
@@ -1191,7 +1191,25 @@ class _VerilogOutput:
         if gate.op == "c":
             if len(verilog_args) == 1:
                 return verilog_args[0]
-            return f"{{{', '.join(verilog_args)}}}"
+
+            concat_args = []
+            replicas = 1
+            for index in range(1, len(verilog_args) + 1):
+                if (
+                    index < len(verilog_args)
+                    and gate.args[index] is gate.args[index - 1]
+                ):
+                    replicas += 1
+                else:
+                    if replicas == 1:
+                        concat_args.append(verilog_args[index - 1])
+                    else:
+                        concat_args.append(
+                            f"{{{replicas} {{{verilog_args[index - 1]}}}}}"
+                        )
+                    replicas = 1
+
+            return f"{{{', '.join(concat_args)}}}"
         if gate.op == "s":
             selections = []
             for sel in reversed(gate.sel):
@@ -1201,9 +1219,6 @@ class _VerilogOutput:
                     selections.append(f"{verilog_args[0]}[{sel}]")
             if len(gate.sel) == 1:
                 return f"({selections[0]})"
-            # Special case: slicing multiple copies of the same gate.
-            if all(sel == gate.sel[0] for sel in gate.sel):
-                return f"{{{len(selections)} {{{selections[0]}}}}}"
             # Special case: slicing a consecutive subset.
             if tuple(range(gate.sel[0], gate.sel[-1] + 1)) == gate.sel:
                 return f"({verilog_args[0]}[{gate.sel[-1]}:{gate.sel[0]}])"

--- a/pyrtl/visualization.py
+++ b/pyrtl/visualization.py
@@ -269,10 +269,6 @@ def _default_node_namer(
                 bits = f"[{selLower}]"
             elif node.op_param == tuple(range(selLower, selUpper + 1)):  # consecutive
                 bits = f"[{selUpper}:{selLower}]"
-            elif all(
-                ix == node.op_param[0] for ix in node.op_param[1:]
-            ):  # all the same
-                bits = f"[{node.op_param[0]}]*{len(node.op_param)}"
             else:
                 bits = "bits" + str(tuple(reversed(node.op_param)))
             return f'[label="{label(bits)}", fillcolor=azure1, height=.25, width=.25]'

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -1400,7 +1400,18 @@ class WireVector:
         :raises PyrtlError: If the ``bitwidth`` specified is smaller than
             :attr:`bitwidth`.
         """
-        return self._extend_with_bit(bitwidth, self[-1])
+        num_added_bits = bitwidth - self.bitwidth
+        if num_added_bits == 0:
+            return self
+        if num_added_bits < 0:
+            msg = "sign_extended can not reduce the number of bits"
+            raise PyrtlError(msg)
+
+        from pyrtl.corecircuits import concat
+
+        sign_bit = self[-1]
+
+        return concat(*([sign_bit] * num_added_bits), self)
 
     def zero_extended(self, bitwidth) -> WireVector:
         """Return a zero-extended copy of ``self``.
@@ -1433,27 +1444,16 @@ class WireVector:
         :raises PyrtlError: If the ``bitwidth`` specified is smaller than
             :attr:`bitwidth`.
         """
-        return self._extend_with_bit(bitwidth, 0)
-
-    def _extend_with_bit(self, bitwidth, extbit):
-        numext = bitwidth - self.bitwidth
-        if numext == 0:
+        num_added_bits = bitwidth - self.bitwidth
+        if num_added_bits == 0:
             return self
-        if numext < 0:
-            msg = (
-                "Neither zero_extended nor sign_extended can reduce the number of bits"
-            )
+        if num_added_bits < 0:
+            msg = "zero_extended can not reduce the number of bits"
             raise PyrtlError(msg)
+
         from pyrtl.corecircuits import concat
 
-        if isinstance(extbit, int):
-            extbit = Const(extbit, bitwidth=1)
-        extvector = WireVector(bitwidth=numext)
-        net = LogicNet(
-            op="s", op_param=(0,) * numext, args=(extbit,), dests=(extvector,)
-        )
-        working_block().add_net(net)
-        return concat(extvector, self)
+        return concat(Const(0, bitwidth=num_added_bits), self)
 
 
 WireVectorLike = WireVector | int | str | bool

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -156,25 +156,25 @@ paths_print_output = """\
 From i
   To o
     Path 0
-      tmp5/3W <-- - -- i/2I, tmp4/2W
-      tmp6/3W <-- | -- tmp2/3W, tmp5/3W
-      o/3O <-- w -- tmp6/3W
+      tmp3/3W <-- - -- i/2I, tmp2/2W
+      tmp4/3W <-- | -- tmp1/3W, tmp3/3W
+      o/3O <-- w -- tmp4/3W
     Path 1
-      tmp1/3W <-- c -- tmp0/1W, i/2I
-      tmp2/3W <-- & -- tmp1/3W, j/3I
-      tmp6/3W <-- | -- tmp2/3W, tmp5/3W
-      o/3O <-- w -- tmp6/3W
+      tmp0/3W <-- c -- const_0_0/1C, i/2I
+      tmp1/3W <-- & -- tmp0/3W, j/3I
+      tmp4/3W <-- | -- tmp1/3W, tmp3/3W
+      o/3O <-- w -- tmp4/3W
   To p
     Path 0
-      tmp8/4W <-- c -- tmp7/2W, i/2I
-      tmp9/5W <-- - -- k/4I, tmp8/4W
-      p/5O <-- w -- tmp9/5W
+      tmp5/4W <-- c -- const_3_0/2C, i/2I
+      tmp6/5W <-- - -- k/4I, tmp5/4W
+      p/5O <-- w -- tmp6/5W
 From j
   To o
     Path 0
-      tmp2/3W <-- & -- tmp1/3W, j/3I
-      tmp6/3W <-- | -- tmp2/3W, tmp5/3W
-      o/3O <-- w -- tmp6/3W
+      tmp1/3W <-- & -- tmp0/3W, j/3I
+      tmp4/3W <-- | -- tmp1/3W, tmp3/3W
+      o/3O <-- w -- tmp4/3W
   To p
     (No paths)
 From k
@@ -182,8 +182,8 @@ From k
     (No paths)
   To p
     Path 0
-      tmp9/5W <-- - -- k/4I, tmp8/4W
-      p/5O <-- w -- tmp9/5W
+      tmp6/5W <-- - -- k/4I, tmp5/4W
+      p/5O <-- w -- tmp6/5W
 """
 
 
@@ -381,6 +381,7 @@ class TestPaths(unittest.TestCase):
         paths = pyrtl.paths()
         output = io.StringIO()
         paths.print(file=output)
+        self.maxDiff = 30000
         self.assertEqual(output.getvalue(), paths_print_output)
 
 

--- a/tests/test_compilesim.py
+++ b/tests/test_compilesim.py
@@ -425,9 +425,6 @@ class SimWithSpecialWiresBase(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()
 
-    def test_reg_directly_before_reg(self):
-        pass
-
     def test_weird_wire_names(self):
         """Some simulations need to be careful when handling special names (eg Fastsim
         June 2016)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,9 +73,6 @@ class TestBlock(unittest.TestCase):
         block = pyrtl.working_block()
         self.assertEqual(block.logic_subset(None), block.logic)
 
-    def test_sanity_check(self):
-        pass
-
     def test_block_iterators(self):
         # testing to see that it properly runs a trivial case
         inwire = pyrtl.Input(bitwidth=1, name="inwire1")
@@ -588,15 +585,6 @@ class TestLogicNets(unittest.TestCase):
     def test_string_format(self):
         net = pyrtl.LogicNet("+", "xx", ("arg1", "arg2"), ("dest",))
         self.assertEqual(str(net), "dest <-- + -- arg1, arg2 (xx)")
-
-    def test_net_with_wirevectors(self):
-        pass
-
-    def test_memory_read_print(self):
-        pass
-
-    def test_memory_write_print(self):
-        pass
 
     def test_self_equals(self):
         a = pyrtl.WireVector()

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -28,9 +28,6 @@ class TestDocTests(unittest.TestCase):
 
 
 class TestWireVectorList(unittest.TestCase):
-    def setUp(self):
-        pass
-
     def test_input_list_type(self):
         inputs = pyrtl.input_list("one, two, three")
         self.assertTrue(all(isinstance(inp, pyrtl.Input) for inp in inputs))
@@ -80,9 +77,6 @@ class TestWireVectorList(unittest.TestCase):
 
 
 class TestNonCoreHelpers(unittest.TestCase):
-    def setUp(self):
-        pass
-
     def test_log2(self):
         self.assertEqual(pyrtl.log2(1), 0)
         self.assertEqual(pyrtl.log2(2), 1)

--- a/tests/test_importexport.py
+++ b/tests/test_importexport.py
@@ -803,7 +803,7 @@ module toplevel(clk, rst, a, o);
     input clk;
     input rst;
     input[3:0] a;
-    output[5:0] o;
+    output[9:0] o;
 
     // Memories
     reg[3:0] z[3:0];  // MemBlock
@@ -825,47 +825,29 @@ module toplevel(clk, rst, a, o);
     reg[3:0] s;
 
     // Temporaries
-    wire[4:0] tmp14;
-    wire[4:0] tmp18;
+    wire[4:0] tmp13;
+    wire[3:0] tmp14;
+    wire[4:0] tmp15;
+    wire[5:0] tmp17;
+    wire[6:0] tmp19;
     wire[4:0] tmp22;
-    wire[4:0] tmp26;
-    wire[4:0] tmp30;
-    wire[4:0] tmp34;
-    wire[4:0] tmp38;
-    wire[4:0] tmp42;
-    wire[4:0] tmp46;
-    wire[4:0] tmp50;
-    wire[4:0] tmp54;
-    wire[4:0] tmp58;
-    wire[4:0] tmp60;
-    wire[5:0] tmp63;
-    wire[6:0] tmp66;
-    wire[4:0] tmp70;
-    wire[3:0] tmp72;
-    wire[5:0] tmp75;
-    wire[3:0] tmp76;
-    wire[6:0] tmp79;
+    wire tmp24;
+    wire[3:0] tmp26;
+    wire[10:0] tmp28;
+    wire[3:0] tmp29;
+    wire[11:0] tmp31;
 
     // Combinational logic
-    assign o = (tmp79[5:0]);
-    assign tmp14 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp18 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp22 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp26 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp30 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp34 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp38 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp42 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp46 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp50 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp54 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp58 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp60 = (a + r);
-    assign tmp63 = (tmp60 + {{4 {1'd0}}, 1'd1});
-    assign tmp66 = (tmp63 - {{2 {1'd0}}, s});
-    assign tmp70 = (a - {{3 {1'd0}}, 1'd1});
-    assign tmp75 = (tmp60 + {(1'd0), tmp72});
-    assign tmp79 = (tmp75 + {{2 {1'd0}}, tmp76});
+    assign o = (tmp31[9:0]);
+    assign tmp13 = (r + {3'd0, 1'd1});
+    assign tmp14 = (tmp13[3:0]);
+    assign tmp15 = (a + r);
+    assign tmp17 = (tmp15 + {4'd0, 1'd1});
+    assign tmp19 = (tmp17 - {2'd0, s});
+    assign tmp22 = (a - {3'd0, 1'd1});
+    assign tmp24 = (tmp15[4]);
+    assign tmp28 = ({{5 {tmp24}}, tmp15} + {6'd0, tmp26});
+    assign tmp31 = (tmp28 + {7'd0, tmp29});
 
     // Register logic
     always @(posedge clk) begin
@@ -873,8 +855,8 @@ module toplevel(clk, rst, a, o);
             r <= 4'd0;
             s <= 4'd13;
         end else begin
-            r <= (tmp66[3:0]);
-            s <= (tmp70[3:0]);
+            r <= (tmp19[3:0]);
+            s <= (tmp22[3:0]);
         end
     end
 
@@ -886,75 +868,75 @@ module toplevel(clk, rst, a, o);
     // MemBlock tmp0 logic
     always @(posedge clk) begin
         tmp0[2'd0] <= a;
-        tmp0[2'd1] <= (tmp14[3:0]);
+        tmp0[2'd1] <= tmp14;
     end
-    assign tmp72 = tmp0[2'd0];
+    assign tmp26 = tmp0[2'd0];
 
     // MemBlock tmp1 logic
     always @(posedge clk) begin
         tmp1[2'd0] <= a;
-        tmp1[2'd1] <= (tmp18[3:0]);
+        tmp1[2'd1] <= tmp14;
     end
-    assign tmp76 = tmp1[2'd0];
+    assign tmp29 = tmp1[2'd0];
 
     // MemBlock tmp2 logic
     always @(posedge clk) begin
         tmp2[2'd0] <= a;
-        tmp2[2'd1] <= (tmp22[3:0]);
+        tmp2[2'd1] <= tmp14;
     end
 
     // MemBlock tmp3 logic
     always @(posedge clk) begin
         tmp3[2'd0] <= a;
-        tmp3[2'd1] <= (tmp26[3:0]);
+        tmp3[2'd1] <= tmp14;
     end
 
     // MemBlock tmp4 logic
     always @(posedge clk) begin
         tmp4[2'd0] <= a;
-        tmp4[2'd1] <= (tmp30[3:0]);
+        tmp4[2'd1] <= tmp14;
     end
 
     // MemBlock tmp5 logic
     always @(posedge clk) begin
         tmp5[2'd0] <= a;
-        tmp5[2'd1] <= (tmp34[3:0]);
+        tmp5[2'd1] <= tmp14;
     end
 
     // MemBlock tmp6 logic
     always @(posedge clk) begin
         tmp6[2'd0] <= a;
-        tmp6[2'd1] <= (tmp38[3:0]);
+        tmp6[2'd1] <= tmp14;
     end
 
     // MemBlock tmp7 logic
     always @(posedge clk) begin
         tmp7[2'd0] <= a;
-        tmp7[2'd1] <= (tmp42[3:0]);
+        tmp7[2'd1] <= tmp14;
     end
 
     // MemBlock tmp8 logic
     always @(posedge clk) begin
         tmp8[2'd0] <= a;
-        tmp8[2'd1] <= (tmp46[3:0]);
+        tmp8[2'd1] <= tmp14;
     end
 
     // MemBlock tmp9 logic
     always @(posedge clk) begin
         tmp9[2'd0] <= a;
-        tmp9[2'd1] <= (tmp50[3:0]);
+        tmp9[2'd1] <= tmp14;
     end
 
     // MemBlock tmp10 logic
     always @(posedge clk) begin
         tmp10[2'd0] <= a;
-        tmp10[2'd1] <= (tmp54[3:0]);
+        tmp10[2'd1] <= tmp14;
     end
 
     // MemBlock tmp11 logic
     always @(posedge clk) begin
         tmp11[2'd0] <= a;
-        tmp11[2'd1] <= (tmp58[3:0]);
+        tmp11[2'd1] <= tmp14;
     end
 endmodule
 """
@@ -1018,18 +1000,18 @@ module toplevel(clk, rst, o);
     reg[3:0] tmp0;
 
     // Temporaries
-    wire[4:0] tmp3;
+    wire[4:0] tmp2;
 
     // Combinational logic
     assign o = tmp0;
-    assign tmp3 = (tmp0 + {{3 {1'd0}}, 1'd1});
+    assign tmp2 = (tmp0 + {3'd0, 1'd1});
 
     // Register logic
     always @(posedge clk) begin
         if (rst) begin
             tmp0 <= 4'd2;
         end else begin
-            tmp0 <= (tmp3[3:0]);
+            tmp0 <= (tmp2[3:0]);
         end
     end
 endmodule
@@ -1050,18 +1032,18 @@ module toplevel(clk, rst, o);
     reg[3:0] tmp0;
 
     // Temporaries
-    wire[4:0] tmp3;
+    wire[4:0] tmp2;
 
     // Combinational logic
     assign o = tmp0;
-    assign tmp3 = (tmp0 + {{3 {1'd0}}, 1'd1});
+    assign tmp2 = (tmp0 + {3'd0, 1'd1});
 
     // Register logic
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             tmp0 <= 4'd2;
         end else begin
-            tmp0 <= (tmp3[3:0]);
+            tmp0 <= (tmp2[3:0]);
         end
     end
 endmodule
@@ -1081,15 +1063,15 @@ module toplevel(clk, o);
     reg[3:0] tmp0;
 
     // Temporaries
-    wire[4:0] tmp3;
+    wire[4:0] tmp2;
 
     // Combinational logic
     assign o = tmp0;
-    assign tmp3 = (tmp0 + {{3 {1'd0}}, 1'd1});
+    assign tmp2 = (tmp0 + {3'd0, 1'd1});
 
     // Register logic
     always @(posedge clk) begin
-        tmp0 <= (tmp3[3:0]);
+        tmp0 <= (tmp2[3:0]);
     end
 endmodule
 """
@@ -1108,16 +1090,16 @@ module toplevel(clk, rst);
     reg[3:0] r;
 
     // Temporaries
-    wire[4:0] tmp2;
-    wire[4:0] tmp5;
+    wire[4:0] tmp1;
+    wire[4:0] tmp3;
 
     // Combinational logic
-    assign tmp2 = (r + {{3 {1'd0}}, 1'd1});
-    assign tmp5 = (rst ? {{4 {1'd0}}, 1'd0} : tmp2);
+    assign tmp1 = (r + {3'd0, 1'd1});
+    assign tmp3 = (rst ? {4'd0, 1'd0} : tmp1);
 
     // Register logic
     always @(posedge clk) begin
-        r <= (tmp5[3:0]);
+        r <= (tmp3[3:0]);
     end
 endmodule
 """
@@ -1209,15 +1191,16 @@ class TestVerilogOutput(unittest.TestCase):
             pyrtl.MemBlock(bitwidth=4, addrwidth=2, max_write_ports=2)
             for _ in range(12)
         ]
+        mem1_value = (r + 1).truncate(4)
         for mem in m:
             mem[0] <<= a
-            mem[1] <<= (r + 1).truncate(4)
+            mem[1] <<= mem1_value
         b = a + r
         r.next <<= b + 1 - s
         s.next <<= a - 1
         mt[0] <<= 9
-        o = pyrtl.Output(6, "o")
-        o <<= b + m[0][0] + m[1][0]
+        o = pyrtl.Output(10, "o")
+        o <<= b.sign_extended(10) + m[0][0] + m[1][0]
 
         buffer = io.StringIO()
         pyrtl.output_to_verilog(buffer)
@@ -1279,6 +1262,7 @@ class TestVerilogOutput(unittest.TestCase):
         r = pyrtl.Register(bitwidth=4, name="r")
         r.next <<= pyrtl.select(rst, 0, r + 1)
         pyrtl.output_to_verilog(buffer, add_reset=False)
+
         self.assertEqual(verilog_custom_reset, buffer.getvalue())
 
     def test_register_reset_value(self):
@@ -1348,7 +1332,6 @@ class TestVerilogOutput(unittest.TestCase):
         buffer = io.StringIO()
         pyrtl.output_to_verilog(buffer)
 
-        print(buffer.getvalue())
         self.assertTrue("assign tmp0 = (a + b)" in buffer.getvalue())
         self.assertTrue("assign tmp2 = (b - a)" in buffer.getvalue())
         self.assertTrue("assign tmp4 = (a * b)" in buffer.getvalue())

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -691,8 +691,8 @@ class TestSubexpElimination(NetWireNumTestCases):
 
         self.num_net_of_type("|", 2)
         self.num_net_of_type("w", 2)
-        self.assert_num_net(6)
-        self.assert_num_wires(9)
+        self.assert_num_net(5)
+        self.assert_num_wires(8)
         pyrtl.working_block().sanity_check()
 
     def test_multiple_elimination(self):
@@ -812,9 +812,6 @@ class TestSynthPasses(unittest.TestCase):
 class TestSynthOptTiming(NetWireNumTestCases):
     def setUp(self):
         pyrtl.reset_working_block()
-
-    def test_sanity_check(self):
-        pass
 
     def everything_t_procedure(self, timing_val=None, opt_timing_val=None):
         # if there is a nondefault timing val supplied, then it will check to make sure

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -134,6 +134,18 @@ class TraceWithBasicOpsBase(unittest.TestCase):
         self.r.next <<= pyrtl.concat(left, right)
         self.check_trace("r 01377777\n")
 
+    def test_non_consecutive_bitslice_simulation(self):
+        pyrtl.reset_working_block()
+
+        input = pyrtl.Input(name="input", bitwidth=8)
+
+        odd_bits = pyrtl.Output(name="odd_bits", bitwidth=4)
+        odd_bits <<= input[1::2]
+
+        sim = self.sim()
+        sim.step({"input": 0b1010_1010})
+        self.assertEqual(sim.inspect("odd_bits"), 0b1111)
+
     def test_reg_to_reg_simulation(self):
         self.r2 = pyrtl.Register(bitwidth=self.bitwidth, name="r2")
         self.r.next <<= self.r2
@@ -471,9 +483,6 @@ class PrintPerfCountersBase(unittest.TestCase):
 class SimWithSpecialWiresBase(unittest.TestCase):
     def setUp(self):
         pyrtl.reset_working_block()
-
-    def test_reg_directly_before_reg(self):
-        pass
 
     def test_weird_wire_names(self):
         """Some simulations need to be careful when handling special names (eg Fastsim

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -29,33 +29,29 @@ digraph g {
     n3 [label="0", shape=circle, fillcolor=lightgrey];
     n4 [label=" (Fanout: 0)", height=.1, width=.1];
     n5 [label="d", shape=house, fillcolor=lawngreen];
-    n6 [label="[0]*2 (Fanout: 1)", fillcolor=azure1, height=.25, width=.25];
-    n7 [label="concat (Fanout: 1)", height=.1, width=.1];
-    n8 [label="* (Fanout: 1)"];
-    n9 [label="[7:2] (Fanout: 1)", fillcolor=azure1, height=.25, width=.25];
-    n10 [label="[0]*4 (Fanout: 1)", fillcolor=azure1, height=.25, width=.25];
-    n11 [label="concat (Fanout: 1)", height=.1, width=.1];
-    n0 -> n7 [label="a/2 (Delay: 0.00)", penwidth="6", arrowhead="none"];
-    n1 -> n8 [label="const_0_8/4 (Delay: 0.00)", penwidth="6", arrowhead="normal"];
-    n2 -> n6 [label="const_1_0/1 (Delay: 0.00)", penwidth="2", arrowhead="none"];
-    n3 -> n10 [label="const_2_0/1 (Delay: 0.00)", penwidth="2", arrowhead="none"];
+    n6 [label="concat (Fanout: 1)", height=.1, width=.1];
+    n7 [label="* (Fanout: 1)"];
+    n8 [label="[7:2] (Fanout: 1)", fillcolor=azure1, height=.25, width=.25];
+    n9 [label="concat (Fanout: 1)", height=.1, width=.1];
+    n0 -> n6 [label="a/2 (Delay: 0.00)", penwidth="6", arrowhead="none"];
+    n1 -> n7 [label="const_0_8/4 (Delay: 0.00)", penwidth="6", arrowhead="normal"];
+    n2 -> n6 [label="const_1_0/2 (Delay: 0.00)", penwidth="6", arrowhead="none"];
+    n3 -> n9 [label="const_2_0/4 (Delay: 0.00)", penwidth="6", arrowhead="none"];
     n4 -> n5 [label="d/10 (Delay: 706.50)", penwidth="6", arrowhead="normal"];
-    n6 -> n7 [label="tmp0/2 (Delay: 0.00)", penwidth="6", arrowhead="none"];
-    n7 -> n8 [label="tmp1/4 (Delay: 0.00)", penwidth="6", arrowhead="normal"];
-    n8 -> n9 [label="tmp2/8 (Delay: 706.50)", penwidth="6", arrowhead="none"];
-    n9 -> n11 [label="tmp3/6 (Delay: 706.50)", penwidth="6", arrowhead="none"];
-    n10 -> n11 [label="tmp4/4 (Delay: 0.00)", penwidth="6", arrowhead="none"];
-    n11 -> n4 [label="tmp5/10 (Delay: 706.50)", penwidth="6", arrowhead="normal"];
+    n6 -> n7 [label="tmp0/4 (Delay: 0.00)", penwidth="6", arrowhead="normal"];
+    n7 -> n8 [label="tmp1/8 (Delay: 706.50)", penwidth="6", arrowhead="none"];
+    n8 -> n9 [label="tmp2/6 (Delay: 706.50)", penwidth="6", arrowhead="none"];
+    n9 -> n4 [label="tmp3/10 (Delay: 706.50)", penwidth="6", arrowhead="normal"];
     {
         rank=same;
         edge[style=invis];
-        n6 -> n0;
+        n2 -> n0;
         rankdir=LR;
     }
     {
         rank=same;
         edge[style=invis];
-        n10 -> n9;
+        n3 -> n8;
         rankdir=LR;
     }
 }
@@ -78,59 +74,53 @@ digraph g {
     n6 [label="o", shape=house, fillcolor=lawngreen];
     n7 [label="", height=.1, width=.1];
     n8 [label="q", shape=house, fillcolor=lawngreen];
-    n9 [label="[0]*4", fillcolor=azure1, height=.25, width=.25];
-    n10 [label="concat", height=.1, width=.1];
-    n11 [label="<"];
-    n12 [label="[0]*7", fillcolor=azure1, height=.25, width=.25];
-    n13 [label="concat", height=.1, width=.1];
-    n14 [label="[0]*4", fillcolor=azure1, height=.25, width=.25];
-    n15 [label="concat", height=.1, width=.1];
-    n16 [label=">"];
-    n0 -> n9 [label="", penwidth="2", arrowhead="none"];
-    n1 -> n12 [label="", penwidth="2", arrowhead="none"];
-    n2 -> n14 [label="", penwidth="2", arrowhead="none"];
-    n3 -> n11 [label="", penwidth="6", arrowhead="normal"];
-    n3 -> n16 [label="", penwidth="6", arrowhead="normal"];
-    n4 -> n10 [label="", penwidth="6", arrowhead="none"];
-    n4 -> n15 [label="", penwidth="6", arrowhead="none"];
+    n9 [label="concat", height=.1, width=.1];
+    n10 [label="<"];
+    n11 [label="concat", height=.1, width=.1];
+    n12 [label="concat", height=.1, width=.1];
+    n13 [label=">"];
+    n0 -> n9 [label="", penwidth="6", arrowhead="none"];
+    n1 -> n11 [label="", penwidth="6", arrowhead="none"];
+    n2 -> n12 [label="", penwidth="6", arrowhead="none"];
+    n3 -> n10 [label="", penwidth="6", arrowhead="normal"];
+    n3 -> n13 [label="", penwidth="6", arrowhead="normal"];
+    n4 -> n9 [label="", penwidth="6", arrowhead="none"];
+    n4 -> n12 [label="", penwidth="6", arrowhead="none"];
     n5 -> n6 [label="", penwidth="6", arrowhead="normal"];
     n7 -> n8 [label="", penwidth="2", arrowhead="normal"];
-    n9 -> n10 [label="", penwidth="6", arrowhead="none"];
-    n10 -> n11 [label="", penwidth="6", arrowhead="normal"];
-    n11 -> n13 [label="", penwidth="2", arrowhead="none"];
-    n12 -> n13 [label="", penwidth="6", arrowhead="none"];
-    n13 -> n5 [label="", penwidth="6", arrowhead="normal"];
-    n14 -> n15 [label="", penwidth="6", arrowhead="none"];
-    n15 -> n16 [label="", penwidth="6", arrowhead="normal"];
-    n16 -> n7 [label="", penwidth="2", arrowhead="normal"];
+    n9 -> n10 [label="", penwidth="6", arrowhead="normal"];
+    n10 -> n11 [label="", penwidth="2", arrowhead="none"];
+    n11 -> n5 [label="", penwidth="6", arrowhead="normal"];
+    n12 -> n13 [label="", penwidth="6", arrowhead="normal"];
+    n13 -> n7 [label="", penwidth="2", arrowhead="normal"];
     {
         rank=same;
         edge[style=invis];
-        n9 -> n4;
+        n0 -> n4;
         rankdir=LR;
     }
     {
         rank=same;
         edge[style=invis];
-        n3 -> n10;
+        n3 -> n9;
         rankdir=LR;
     }
     {
         rank=same;
         edge[style=invis];
-        n12 -> n11;
+        n1 -> n10;
         rankdir=LR;
     }
     {
         rank=same;
         edge[style=invis];
-        n14 -> n4;
+        n2 -> n4;
         rankdir=LR;
     }
     {
         rank=same;
         edge[style=invis];
-        n15 -> n3;
+        n12 -> n3;
         rankdir=LR;
     }
 }
@@ -153,31 +143,25 @@ digraph g {
     n6 [label="o", shape=house, fillcolor=lawngreen];
     n7 [label="", height=.1, width=.1];
     n8 [label="q", shape=house, fillcolor=lawngreen];
-    n9 [label="[0]*4", fillcolor=azure1, height=.25, width=.25];
-    n10 [label="concat", height=.1, width=.1];
-    n11 [label="<"];
-    n12 [label="[0]*7", fillcolor=azure1, height=.25, width=.25];
-    n13 [label="concat", height=.1, width=.1];
-    n14 [label="[0]*4", fillcolor=azure1, height=.25, width=.25];
-    n15 [label="concat", height=.1, width=.1];
-    n16 [label=">"];
-    n0 -> n9 [label="", penwidth="2", arrowhead="none"];
-    n1 -> n12 [label="", penwidth="2", arrowhead="none"];
-    n2 -> n14 [label="", penwidth="2", arrowhead="none"];
-    n3 -> n11 [label="", penwidth="6", arrowhead="normal"];
-    n3 -> n16 [label="", penwidth="6", arrowhead="normal"];
-    n4 -> n10 [label="", penwidth="6", arrowhead="none"];
-    n4 -> n15 [label="", penwidth="6", arrowhead="none"];
+    n9 [label="concat", height=.1, width=.1];
+    n10 [label="<"];
+    n11 [label="concat", height=.1, width=.1];
+    n12 [label="concat", height=.1, width=.1];
+    n13 [label=">"];
+    n0 -> n9 [label="", penwidth="6", arrowhead="none"];
+    n1 -> n11 [label="", penwidth="6", arrowhead="none"];
+    n2 -> n12 [label="", penwidth="6", arrowhead="none"];
+    n3 -> n10 [label="", penwidth="6", arrowhead="normal"];
+    n3 -> n13 [label="", penwidth="6", arrowhead="normal"];
+    n4 -> n9 [label="", penwidth="6", arrowhead="none"];
+    n4 -> n12 [label="", penwidth="6", arrowhead="none"];
     n5 -> n6 [label="", penwidth="6", arrowhead="normal"];
     n7 -> n8 [label="", penwidth="2", arrowhead="normal"];
-    n9 -> n10 [label="", penwidth="6", arrowhead="none"];
-    n10 -> n11 [label="", penwidth="6", arrowhead="normal"];
-    n11 -> n13 [label="", penwidth="2", arrowhead="none"];
-    n12 -> n13 [label="", penwidth="6", arrowhead="none"];
-    n13 -> n5 [label="", penwidth="6", arrowhead="normal"];
-    n14 -> n15 [label="", penwidth="6", arrowhead="none"];
-    n15 -> n16 [label="", penwidth="6", arrowhead="normal"];
-    n16 -> n7 [label="", penwidth="2", arrowhead="normal"];
+    n9 -> n10 [label="", penwidth="6", arrowhead="normal"];
+    n10 -> n11 [label="", penwidth="2", arrowhead="none"];
+    n11 -> n5 [label="", penwidth="6", arrowhead="normal"];
+    n12 -> n13 [label="", penwidth="6", arrowhead="normal"];
+    n13 -> n7 [label="", penwidth="2", arrowhead="normal"];
 }
 
 """
@@ -251,6 +235,7 @@ class TestOutputGraphs(unittest.TestCase):
                 namer=pyrtl.graphviz_detailed_namer(node_fanout, wire_delay),
                 maintain_arg_order=True,
             )
+            self.maxDiff = 10000
             self.assertEqual(vfile.getvalue(), graphviz_string_detailed)
 
     def test_output_to_graphviz_correct_output_with_arg_ordering(self):
@@ -263,6 +248,7 @@ class TestOutputGraphs(unittest.TestCase):
 
         with io.StringIO() as vfile:
             pyrtl.output_to_graphviz(file=vfile, maintain_arg_order=True)
+            self.maxDiff = 10000
             self.assertEqual(vfile.getvalue(), graphviz_string_arg_ordered)
 
     def test_output_to_graphviz_correct_output_without_arg_ordering(self):
@@ -275,6 +261,7 @@ class TestOutputGraphs(unittest.TestCase):
 
         with io.StringIO() as vfile:
             pyrtl.output_to_graphviz(file=vfile)
+            self.maxDiff = 10000
             self.assertEqual(vfile.getvalue(), graphviz_string_arg_unordered)
 
 

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -43,15 +43,6 @@ class TestWireVector(unittest.TestCase):
         with self.assertRaises(TypeError):
             y <<= x
 
-    def test_zero_extend(self):
-        pass
-
-    def test_sign_extend(self):
-        pass
-
-    def test_truncating(self):
-        pass
-
     def test_rename(self):
         block = pyrtl.working_block()
         w = pyrtl.WireVector(1, "test1")
@@ -143,6 +134,8 @@ class TestWireVectorFail(unittest.TestCase):
         x = pyrtl.WireVector(bitwidth=3)
         with self.assertRaises(pyrtl.PyrtlError):
             x.zero_extended(2)
+        with self.assertRaises(pyrtl.PyrtlError):
+            x.sign_extended(2)
 
     def test_truncate_only_reduces_bitwidth(self):
         x = pyrtl.WireVector(bitwidth=3)


### PR DESCRIPTION
This removes 9% of pyrtlnet's slice (`s`) `LogicNets`, and 6% of pyrtlnet's wire (`W`) `WireVectors`, without introducing any new `LogicNets` or `WireVectors`. This speeds up simulation times, especially with `pyrtl.Simulation`.

Fix tests broken by this change.