### PR TITLE
 Disable the `deploy-pages` action when running outside of `UCSBarchlab/development`.

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -22,6 +22,8 @@ jobs:
         path: www/_build/html
 
   deploy:
+    # Only deploy for UCSBarchlab/PyRTL.
+    if: ${{ github.repository == 'UCSBarchlab/PyRTL' && github.ref_name == 'development' }}
     needs: build
     permissions:
       pages: write

--- a/README.md
+++ b/README.md
@@ -200,4 +200,4 @@ It is always important to point out that PyRTL builds on the ideas of several
 other related projects as we all share the common goal of trying to make
 hardware design a better experience! You can read more about those
 relationships on our [PyRTL project web
-page](http://ucsbarchlab.github.io/PyRTL/).
+page](https://pyrtl.readthedocs.io/en/latest/#related-projects)

--- a/www/index.rst
+++ b/www/index.rst
@@ -221,8 +221,8 @@ Notebooks on any of our examples on MyBinder
 Hello N-bit Ripple-Carry Adder!
 ===============================
 
-While adders are a builtin primitive for PyRTL, most people doing RTL are
-familiar with the idea of a `Ripple-Carry Adder
+While adders are a builtin primitive for PyRTL, most people writing RTL are
+familiar with `Ripple-Carry Adders
 <https://en.wikipedia.org/wiki/Adder_(electronics)>`_ and so it is useful to
 see how you might express one in PyRTL. Rather than the typical `Verilog
 introduction to fixed 4-bit adders
@@ -235,9 +235,9 @@ The code above includes ``ripple_add``, an adder generator with Python-style
 slices on wires, ``counter``, an instance of :class:`~pyrtl.Register`, and all
 the code needed to simulate the design, generate a waveform, and render it to
 the terminal. `Example 2
-<https://github.com/UCSBarchlab/PyRTL/blob/development/examples/example2-counter.py>`_'s
-comments describe this code in much more detail. Running this code shows a
-counter running from 0 to 7 and repeating:
+<https://github.com/UCSBarchlab/PyRTL/blob/development/examples/example2-counter.py>`_
+has more comments on how this code works. Running this code shows a counter
+running from 0 to 7 and repeating:
 
 .. image:: ../docs/screenshots/ripple-carry.png
    :width: 34em


### PR DESCRIPTION
This prevents forks from publishing more copies of the website.

Also: Update related projects link in `README.md` and minor website edits.