### PR TITLE
Run all presubmit checks on all tested platforms.

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -26,7 +26,7 @@ jobs:
           brew install -y yosys
         fi
     - name: Run tests
-      run: uv run just tests
+      run: uv run just presubmit
     - name: Upload coverage to Codecov
       if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
This checks that we can build the `sphinx` documentation and webpage, which weren't tested before.