### PR TITLE
Feature: more typing

### DIFF
--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import itertools
-
-from typing import Sequence, Iterable
+from collections.abc import Iterator, Sequence
 
 from pyrtl.conditional import otherwise
 from pyrtl.core import Block, LogicNet, working_block
@@ -707,7 +706,7 @@ def shift_right_logical(
     return barrel.barrel_shifter(bits_to_shift, bit_in, dir, shift_amount)
 
 
-def match_bitwidth(*args: WireVector, signed: bool = False) -> Iterable[WireVector, ...]:
+def match_bitwidth(*args: WireVector, signed: bool = False) -> Iterator[WireVector]:
     """Matches multiple :class:`WireVector` :attr:`bitwidths<~WireVector.bitwidth>` via
     zero- or sign-extension.
 

--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -228,6 +228,7 @@ def concat(*args: WireVectorLike) -> WireVector:
     working_block().add_net(net)
     return outwire
 
+
 def concat_list(wire_list: Sequence[WireVectorLike]) -> WireVector:
     """Concatenates a list of :class:`WireVectors<WireVector>` into a single
     :class:`WireVector`.

--- a/pyrtl/corecircuits.py
+++ b/pyrtl/corecircuits.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import itertools
 
+from typing import Sequence, Iterable
+
 from pyrtl.conditional import otherwise
 from pyrtl.core import Block, LogicNet, working_block
 from pyrtl.pyrtlexceptions import PyrtlError, PyrtlInternalError
@@ -227,8 +229,7 @@ def concat(*args: WireVectorLike) -> WireVector:
     working_block().add_net(net)
     return outwire
 
-
-def concat_list(wire_list: list[WireVectorLike]) -> WireVector:
+def concat_list(wire_list: Sequence[WireVectorLike]) -> WireVector:
     """Concatenates a list of :class:`WireVectors<WireVector>` into a single
     :class:`WireVector`.
 
@@ -706,7 +707,7 @@ def shift_right_logical(
     return barrel.barrel_shifter(bits_to_shift, bit_in, dir, shift_amount)
 
 
-def match_bitwidth(*args: WireVector, signed: bool = False) -> tuple[WireVector]:
+def match_bitwidth(*args: WireVector, signed: bool = False) -> Iterable[WireVector, ...]:
     """Matches multiple :class:`WireVector` :attr:`bitwidths<~WireVector.bitwidth>` via
     zero- or sign-extension.
 

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -2041,7 +2041,7 @@ class Register(WireVector):
         raise PyrtlError(msg)
 
     @next.setter
-    def next(self, other: WireVectorLike):
+    def next(self, other: Register._Next):  # other: WireVectorLike
         if not isinstance(other, Register._Next):
             msg = 'error, .next should be set with "<<=" or "|=" operators'
             raise PyrtlError(msg)

--- a/pyrtl/wire.py
+++ b/pyrtl/wire.py
@@ -2041,7 +2041,7 @@ class Register(WireVector):
         raise PyrtlError(msg)
 
     @next.setter
-    def next(self, other: Register._Next):  # other: WireVectorLike
+    def next(self, other: Register._Next):
         if not isinstance(other, Register._Next):
             msg = 'error, .next should be set with "<<=" or "|=" operators'
             raise PyrtlError(msg)

--- a/www/examples/example-adder.py
+++ b/www/examples/example-adder.py
@@ -19,10 +19,10 @@ def adder(
     a, b = pyrtl.match_bitwidth(a, b)
 
     sum: list[pyrtl.WireVector] = []
+    cout = cin
     for i in range(a.bitwidth):
-        s, cout = fa(a[i], b[i], cin)
+        s, cout = fa(a[i], b[i], cout)
         sum.append(s)
-        cin = cout
 
     full_sum = pyrtl.concat_list(sum)
     return full_sum, cout

--- a/www/examples/example-adder.py
+++ b/www/examples/example-adder.py
@@ -18,7 +18,7 @@ def adder(
     """n-bit ripple carry adder with carry in and carry out."""
     a, b = pyrtl.match_bitwidth(a, b)
 
-    sum = []
+    sum: list[pyrtl.WireVector] = []
     for i in range(a.bitwidth):
         s, cout = fa(a[i], b[i], cin)
         sum.append(s)

--- a/www/examples/example-adder.py
+++ b/www/examples/example-adder.py
@@ -18,9 +18,10 @@ def adder(
     """n-bit ripple carry adder with carry in and carry out."""
     a, b = pyrtl.match_bitwidth(a, b)
 
-    sum = [None] * a.bitwidth
+    sum = []
     for i in range(a.bitwidth):
-        sum[i], cout = fa(a[i], b[i], cin)
+        s, cout = fa(a[i], b[i], cin)
+        sum.append(s)
         cin = cout
 
     full_sum = pyrtl.concat_list(sum)

--- a/www/examples/example-fir.py
+++ b/www/examples/example-fir.py
@@ -1,4 +1,5 @@
 import pyrtl
+import itertools
 
 # # Finite impulse filter example.
 
@@ -7,10 +8,11 @@ def fir(x: pyrtl.WireVector, bs: list[int]):
     rwidth = x.bitwidth  # Bitwidth of the registers.
     ntaps = len(bs)  # Number of coefficients.
 
+    # Create a chain of registers.
     regs = [pyrtl.Register(rwidth) for _ in range(ntaps - 1)]
-    for i, reg in enumerate(regs):
-        reg.next <<= x if i == 0 else regs[i - 1]
-
+    regs[0].next <<= x
+    for prev, curr in itertools.pairwise(regs):
+        curr.next <<= prev
     zs = [x, *regs]
 
     # Produce the final sum of products.

--- a/www/examples/example-fir.py
+++ b/www/examples/example-fir.py
@@ -7,9 +7,11 @@ def fir(x: pyrtl.WireVector, bs: list[int]):
     rwidth = x.bitwidth  # Bitwidth of the registers.
     ntaps = len(bs)  # Number of coefficients.
 
-    zs = [x] + [pyrtl.Register(rwidth) for _ in range(ntaps - 1)]
-    for i in range(1, ntaps):
-        zs[i].next <<= zs[i - 1]
+    regs = [pyrtl.Register(rwidth) for _ in range(ntaps - 1)]
+    for i, reg in enumerate(regs):
+        reg.next <<= x if i == 0 else regs[i - 1]
+
+    zs = [x, *regs]
 
     # Produce the final sum of products.
     return sum(z * b for z, b in zip(zs, bs, strict=True))


### PR DESCRIPTION
#511

- Fix the `Register.next` setter annotation to reflect that augmented assignment passes a `Register._Next` object back through the setter.
- Change `match_bitwidth`'s return type to `Iterator[WireVector]`, matching its current generator-based implementation.
- Change `concat_list`'s parameter type from `list[WireVectorLike]` to `Sequence[WireVectorLike]`.
- New implementation of [adder](www/examples/example-adder.py) and [fir](www/examples/example-fir.py).

The typing changes are annotation-only and do not change runtime behavior.

This PR focuses only on fixing the identified type annotations. I have not added repository-wide type-regression testing yet, since doing that robustly is a substantially larger piece of work.

A useful regression test would first require choosing a representative baseline and defining what it means for the typing state to become "no worse." This is not necessarily equivalent to comparing the number of diagnostics: a future change might eliminate several existing errors while introducing a smaller number of different errors, and it is not obvious whether that should be considered an improvement or a regression.

It would therefore be better to design the baseline and comparison policy separately, rather than introducing a fragile diagnostic-counting test as part of this PR.